### PR TITLE
Format production values and fix asset card units

### DIFF
--- a/src/lib/components/patterns/assets/AssetCard.svelte
+++ b/src/lib/components/patterns/assets/AssetCard.svelte
@@ -3,7 +3,7 @@
 	import type { Asset, Token } from '$lib/types/uiTypes';
 	import { useTokenService } from '$lib/services';
 	import { Card, CardImage, CardContent, CardActions, PrimaryButton, SecondaryButton } from '$lib/components/components';
-	import { formatCurrency, formatEndDate } from '$lib/utils/formatters';
+	import { formatCurrency, formatEndDate, formatProductionValue } from '$lib/utils/formatters';
     import { getTokenReturns } from '$lib/utils';
     import type { TokenMetadata } from '$lib/types/MetaboardTypes';
 
@@ -135,7 +135,7 @@
 		<!-- Key Stats -->
 		<div class={highlightedStatsClasses}>
 			<div class={highlightStatClasses}>
-				<span class={highlightValueClasses}>{asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0).toFixed(2) || 'TBD'}</span>
+				<span class={highlightValueClasses}>{formatProductionValue(asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0))}</span>
 				<span class={highlightLabelClasses}>Exp. Remaining</span>
 			</div>
 			{#if latestReport}

--- a/src/lib/components/patterns/assets/AssetCard.svelte
+++ b/src/lib/components/patterns/assets/AssetCard.svelte
@@ -3,7 +3,7 @@
 	import type { Asset, Token } from '$lib/types/uiTypes';
 	import { useTokenService } from '$lib/services';
 	import { Card, CardImage, CardContent, CardActions, PrimaryButton, SecondaryButton } from '$lib/components/components';
-	import { formatCurrency, formatEndDate, formatProductionValue } from '$lib/utils/formatters';
+	import { formatCurrency, formatEndDate, formatSmartNumber } from '$lib/utils/formatters';
     import { getTokenReturns } from '$lib/utils';
     import type { TokenMetadata } from '$lib/types/MetaboardTypes';
 
@@ -135,7 +135,7 @@
 		<!-- Key Stats -->
 		<div class={highlightedStatsClasses}>
 			<div class={highlightStatClasses}>
-				<span class={highlightValueClasses}>{formatProductionValue(asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0))}</span>
+				<span class={highlightValueClasses}>{asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0) ? formatSmartNumber(asset.plannedProduction.projections.reduce((acc, curr) => acc + curr.production, 0), { suffix: ' boe' }) : 'TBD'}</span>
 				<span class={highlightLabelClasses}>Exp. Remaining</span>
 			</div>
 			{#if latestReport}

--- a/src/lib/components/patterns/assets/AssetDetailHeader.svelte
+++ b/src/lib/components/patterns/assets/AssetDetailHeader.svelte
@@ -160,7 +160,7 @@
 		<div class="grid grid-cols-3 gap-2 sm:gap-4 lg:gap-8 text-center mb-6 lg:mb-8">
 			<StatsCard
 				title="Current Production"
-				value={asset?.production?.current ? asset.production.current.replace(' BOE/month', '') : '0'}
+				value={asset?.production?.current ? asset.production.current.replace(' BOE/month', '').replace(' boe/day', '') : '0'}
 				subtitle="BOE/month"
 				size="small"
 			/>

--- a/src/lib/components/patterns/carousel/FeaturedTokenCarousel.svelte
+++ b/src/lib/components/patterns/carousel/FeaturedTokenCarousel.svelte
@@ -4,7 +4,7 @@
 	import type { Token, Asset } from '$lib/types/uiTypes';
 	import { PrimaryButton, SecondaryButton, FormattedNumber, FormattedReturn } from '$lib/components/components';
 	import { sftMetadata, sfts } from '$lib/stores';
-	import { formatCurrency, formatTokenSupply, formatSmartReturn, formatProductionValue } from '$lib/utils/formatters';
+	import { formatCurrency, formatTokenSupply, formatSmartReturn, formatSmartNumber } from '$lib/utils/formatters';
 	import { meetsSupplyThreshold, formatSupplyAmount, getAvailableSupplyBigInt } from '$lib/utils/tokenSupplyUtils';
     import { decodeSftInformation } from '$lib/decodeMetadata/helpers';
 	import { readContract } from '@wagmi/core';
@@ -415,7 +415,7 @@
 					<div class={assetStatsClasses}>
 						<div class={statItemClasses}>
 							<div class={statLabelClasses}>Remaining Production</div>
-							<div class={statValueClasses}>{formatProductionValue(item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0))}</div>
+							<div class={statValueClasses}>{item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0) ? formatSmartNumber(item.asset.plannedProduction.projections.reduce((acc, curr) => acc + curr.production, 0), { suffix: ' boe' }) : 'TBD'}</div>
 						</div>
 					</div>
 
@@ -432,7 +432,7 @@
 					<h3 class={assetNameClasses}>{item.asset.name}</h3>
 					<div class="text-sm text-black opacity-70">
 						<span class="font-medium">Remaining Production:</span> 
-						<span>{formatProductionValue(item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0))}</span>
+						<span>{item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0) ? formatSmartNumber(item.asset.plannedProduction.projections.reduce((acc, curr) => acc + curr.production, 0), { suffix: ' boe' }) : 'TBD'}</span>
 					</div>
 				</div>
 							</div>

--- a/src/lib/components/patterns/carousel/FeaturedTokenCarousel.svelte
+++ b/src/lib/components/patterns/carousel/FeaturedTokenCarousel.svelte
@@ -4,7 +4,7 @@
 	import type { Token, Asset } from '$lib/types/uiTypes';
 	import { PrimaryButton, SecondaryButton, FormattedNumber, FormattedReturn } from '$lib/components/components';
 	import { sftMetadata, sfts } from '$lib/stores';
-	import { formatCurrency, formatTokenSupply, formatSmartReturn } from '$lib/utils/formatters';
+	import { formatCurrency, formatTokenSupply, formatSmartReturn, formatProductionValue } from '$lib/utils/formatters';
 	import { meetsSupplyThreshold, formatSupplyAmount, getAvailableSupplyBigInt } from '$lib/utils/tokenSupplyUtils';
     import { decodeSftInformation } from '$lib/decodeMetadata/helpers';
 	import { readContract } from '@wagmi/core';
@@ -415,7 +415,7 @@
 					<div class={assetStatsClasses}>
 						<div class={statItemClasses}>
 							<div class={statLabelClasses}>Remaining Production</div>
-							<div class={statValueClasses}>{item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0).toFixed(2) || 'TBD'}</div>
+							<div class={statValueClasses}>{formatProductionValue(item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0))}</div>
 						</div>
 					</div>
 
@@ -432,7 +432,7 @@
 					<h3 class={assetNameClasses}>{item.asset.name}</h3>
 					<div class="text-sm text-black opacity-70">
 						<span class="font-medium">Remaining Production:</span> 
-						<span>{item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0).toFixed(2) || 'TBD'}</span>
+						<span>{formatProductionValue(item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0))}</span>
 					</div>
 				</div>
 							</div>

--- a/src/lib/types/transformations.ts
+++ b/src/lib/types/transformations.ts
@@ -26,7 +26,7 @@ import type {
   AssetLocation as UIAssetLocation
 } from './uiTypes';
 import type { ISODateOnlyString, ISODateTimeString } from './sharedTypes';
-import { formatCurrency, formatNumber, formatProductionValue } from '../utils/formatters';
+import { formatCurrency, formatNumber, formatSmartNumber } from '../utils/formatters';
 
 /**
  * Core domain types - pure data representation
@@ -328,7 +328,7 @@ export class TypeTransformations {
         production: {
           status: asset.production.status,
           statusDisplay: asset.production.status.charAt(0).toUpperCase() + asset.production.status.slice(1),
-                  expectedRemainingProduction: formatProductionValue(asset.production.expectedRemainingProduction),
+                              expectedRemainingProduction: asset.production.expectedRemainingProduction !== null ? formatSmartNumber(asset.production.expectedRemainingProduction, { suffix: ' boe' }) : 'TBD',
           expectedEndDate: asset.production.expectedEndDate
             ? this.formatEndDate(asset.production.expectedEndDate)
             : 'TBD'
@@ -522,7 +522,7 @@ export class TypeTransformations {
         (sum, proj) => sum + proj.production, 
         0
       );
-      uiAsset.production.expectedRemainingProduction = formatProductionValue(totalPlannedProduction);
+      uiAsset.production.expectedRemainingProduction = totalPlannedProduction ? formatSmartNumber(totalPlannedProduction, { suffix: ' boe' }) : 'TBD';
     }
     
     // Set current production from latest monthly report

--- a/src/lib/types/transformations.ts
+++ b/src/lib/types/transformations.ts
@@ -26,7 +26,7 @@ import type {
   AssetLocation as UIAssetLocation
 } from './uiTypes';
 import type { ISODateOnlyString, ISODateTimeString } from './sharedTypes';
-import { formatCurrency, formatNumber } from '../utils/formatters';
+import { formatCurrency, formatNumber, formatProductionValue } from '../utils/formatters';
 
 /**
  * Core domain types - pure data representation
@@ -328,9 +328,7 @@ export class TypeTransformations {
         production: {
           status: asset.production.status,
           statusDisplay: asset.production.status.charAt(0).toUpperCase() + asset.production.status.slice(1),
-          expectedRemainingProduction: asset.production.expectedRemainingProduction !== null
-            ? `${(asset.production.expectedRemainingProduction / 1000).toFixed(1)}k boe`
-            : 'TBD',
+                  expectedRemainingProduction: formatProductionValue(asset.production.expectedRemainingProduction),
           expectedEndDate: asset.production.expectedEndDate
             ? this.formatEndDate(asset.production.expectedEndDate)
             : 'TBD'
@@ -524,9 +522,7 @@ export class TypeTransformations {
         (sum, proj) => sum + proj.production, 
         0
       );
-      uiAsset.production.expectedRemainingProduction = totalPlannedProduction ? 
-        `${(totalPlannedProduction / 1000).toFixed(1)}k boe` : 
-        'TBD';
+      uiAsset.production.expectedRemainingProduction = formatProductionValue(totalPlannedProduction);
     }
     
     // Set current production from latest monthly report

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -369,3 +369,40 @@ export function formatSmartReturn(
   // For multipliers below 10x, show with one decimal if needed
   return `${multiplier.toFixed(1)}x`;
 }
+
+/**
+ * Formats production values with smart formatting and proper units
+ * @param value - Production value in BOE
+ * @param options - Formatting options
+ * @returns Formatted production string (e.g., "1,234 boe" or "12.5k boe")
+ */
+export function formatProductionValue(
+  value: number | undefined | null,
+  options: {
+    unit?: string;          // Unit to append (default: 'boe')
+    threshold?: number;     // When to switch to k format (default: 10000)
+    includeUnit?: boolean;  // Whether to include the unit (default: true)
+  } = {}
+): string {
+  if (value === undefined || value === null || isNaN(value)) {
+    return 'TBD';
+  }
+
+  const { 
+    unit = 'boe', 
+    threshold = 10000, 
+    includeUnit = true 
+  } = options;
+
+  let formatted: string;
+  
+  if (value >= threshold) {
+    // Use k format with 1 decimal place
+    formatted = `${(value / 1000).toFixed(1)}k`;
+  } else {
+    // Use regular format with commas
+    formatted = formatNumber(value);
+  }
+
+  return includeUnit ? `${formatted} ${unit}` : formatted;
+}

--- a/src/lib/utils/formatters.ts
+++ b/src/lib/utils/formatters.ts
@@ -370,39 +370,3 @@ export function formatSmartReturn(
   return `${multiplier.toFixed(1)}x`;
 }
 
-/**
- * Formats production values with smart formatting and proper units
- * @param value - Production value in BOE
- * @param options - Formatting options
- * @returns Formatted production string (e.g., "1,234 boe" or "12.5k boe")
- */
-export function formatProductionValue(
-  value: number | undefined | null,
-  options: {
-    unit?: string;          // Unit to append (default: 'boe')
-    threshold?: number;     // When to switch to k format (default: 10000)
-    includeUnit?: boolean;  // Whether to include the unit (default: true)
-  } = {}
-): string {
-  if (value === undefined || value === null || isNaN(value)) {
-    return 'TBD';
-  }
-
-  const { 
-    unit = 'boe', 
-    threshold = 10000, 
-    includeUnit = true 
-  } = options;
-
-  let formatted: string;
-  
-  if (value >= threshold) {
-    // Use k format with 1 decimal place
-    formatted = `${(value / 1000).toFixed(1)}k`;
-  } else {
-    // Use regular format with commas
-    formatted = formatNumber(value);
-  }
-
-  return includeUnit ? `${formatted} ${unit}` : formatted;
-}


### PR DESCRIPTION
Standardize production value formatting and remove redundant units using existing `formatSmartNumber` utility.

The initial implementation introduced a new formatting function. This PR refactors to use the existing `formatSmartNumber` utility, ensuring consistency with other number formatting in the codebase and avoiding code duplication, as per user feedback. This also addresses the user's request for specific formatting (commas, 'k' for large numbers, 'boe' unit) and removes duplicate units from the asset detail header.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6435596e-da8c-4a37-9327-bb44eb0b360c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6435596e-da8c-4a37-9327-bb44eb0b360c)