### PR TITLE
Adjust mobile layout for picture section

### DIFF
--- a/src/lib/components/patterns/assets/AssetDetailHeader.svelte
+++ b/src/lib/components/patterns/assets/AssetDetailHeader.svelte
@@ -78,8 +78,8 @@
 		<div class="py-6 sm:py-8 lg:py-12">
 			<div class="mb-6 sm:mb-8 lg:mb-12">
 							<div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:gap-8 mb-6 lg:mb-8">
-				<!-- Thumbnail - hidden on mobile -->
-				<div class="hidden sm:block w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 rounded-lg overflow-hidden border border-light-gray flex-shrink-0">
+				<!-- Thumbnail - now shown on mobile too -->
+				<div class="w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 rounded-lg overflow-hidden border border-light-gray flex-shrink-0">
 					<img 
 						src={getImageUrl(getAssetImage(asset))} 
 						alt={asset?.name || 'Asset'}
@@ -89,7 +89,7 @@
 				</div>
 					<div class="flex-1">
 						<div class="flex flex-col gap-4 lg:flex-row lg:justify-between lg:items-start lg:gap-4 mb-4">
-							<h1 class="text-2xl sm:text-3xl lg:text-4xl xl:text-5xl font-extrabold text-black uppercase tracking-tight m-0 leading-tight">{asset?.name}</h1>
+							<h1 class="hidden sm:block text-2xl sm:text-3xl lg:text-4xl xl:text-5xl font-extrabold text-black uppercase tracking-tight m-0 leading-tight">{asset?.name}</h1>
 							
 							<!-- Mobile sharing button -->
 							<div class="flex lg:hidden justify-end">
@@ -144,10 +144,10 @@
 								</div>
 							</div>
 						</div>
-						<div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4 mb-2">
+						<div class="hidden sm:flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4 mb-2">
 							<span class="text-secondary font-medium text-sm">📍 {asset?.location?.state}, {asset?.location?.country}</span>
 						</div>
-						<div class="text-black opacity-70 text-sm">
+						<div class="hidden sm:block text-black opacity-70 text-sm">
 							<span>Operated by {asset?.operator?.name}</span>
 							<span class="hidden sm:inline">•</span>
 							<span class="block sm:inline">License {asset?.technical?.license}</span>
@@ -156,8 +156,8 @@
 				</div>
 			</div>
 
-					<!-- Mobile: Compact inline stats -->
-		<div class="grid grid-cols-3 gap-2 sm:gap-4 lg:gap-8 text-center mb-6 lg:mb-8">
+					<!-- Mobile: Compact inline stats - hidden on mobile -->
+		<div class="hidden sm:grid grid-cols-3 gap-2 sm:gap-4 lg:gap-8 text-center mb-6 lg:mb-8">
 			<StatsCard
 				title="Current Production"
 				value={asset?.production?.current ? asset.production.current.replace(' BOE/month', '').replace(' boe/day', '') : '0'}

--- a/src/routes/(main)/assets/[id]/+page.svelte
+++ b/src/routes/(main)/assets/[id]/+page.svelte
@@ -191,14 +191,23 @@
 			<a href="/assets" class="px-8 py-4 no-underline font-semibold text-sm uppercase tracking-wider transition-colors duration-200 inline-block bg-black text-white hover:bg-secondary inline-block">Back to Assets</a>
 		</div>
 	{:else}
-		<AssetDetailHeader 
-			asset={assetData!} 
-			tokenCount={assetTokens.length} 
-			onTokenSectionClick={() => document.getElementById('token-section')?.scrollIntoView({ behavior: 'smooth' })}
-		/>
+		<!-- Mobile-only breadcrumb -->
+		<div class="lg:hidden max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+			<nav class="mb-4 sm:mb-6 lg:mb-8 text-sm font-medium">
+				<a href="/assets" class="text-secondary no-underline hover:text-black">← Back to Assets</a>
+			</nav>
+		</div>
+		
+		<div class="hidden lg:block">
+			<AssetDetailHeader 
+				asset={assetData!} 
+				tokenCount={assetTokens.length} 
+				onTokenSectionClick={() => document.getElementById('token-section')?.scrollIntoView({ behavior: 'smooth' })}
+			/>
+		</div>
 
-		<!-- Asset Details Content -->
-        <ContentSection background="white" padding="standard">
+		<!-- Asset Details Content - hidden on mobile -->
+        <ContentSection background="white" padding="standard" className="hidden lg:block">
         	<!-- Mobile: Collapsible sections -->
         	<div class="lg:hidden space-y-4">
         		<!-- Overview in collapsible section -->
@@ -206,8 +215,8 @@
         			<AssetOverviewTab asset={assetData!} />
         		</CollapsibleSection>
         		
-        		<!-- Other sections in collapsible format -->
-        		<CollapsibleSection title="Production Data" isOpenByDefault={false} alwaysOpenOnDesktop={false}>
+        		<!-- Other sections in collapsible format - hide production data on mobile -->
+        		<CollapsibleSection title="Production Data" isOpenByDefault={false} alwaysOpenOnDesktop={false} className="hidden">
         			{@const productionReports = assetData?.productionHistory || assetData?.monthlyReports || []}
 					{@const maxProduction = productionReports.length > 0 ? Math.max(...productionReports.map((r: any) => r.production)) : 100}
 					<div class="flex-1 flex flex-col">
@@ -613,8 +622,9 @@
 	</ContentSection>
 
 		<!-- Available Tokens Section -->
-		<ContentSection background="white" padding="compact">
-			<div class="bg-white border border-light-gray section-no-border" id="token-section">
+		<div class="lg:bg-white bg-transparent py-6 sm:py-8 lg:py-12">
+			<div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+			<div class="lg:bg-white lg:border lg:border-light-gray bg-transparent border-none section-no-border" id="token-section">
 				<div class="py-6">
 					<h3 class="text-3xl md:text-2xl font-extrabold text-black uppercase tracking-wider mb-8">Token Information</h3>
 				<div class="grid grid-cols-1 md:grid-cols-2 gap-8">
@@ -631,6 +641,16 @@
 									<div class="relative preserve-3d transform-gpu transition-transform duration-500 {isFlipped ? 'rotate-y-180' : ''} min-h-[700px] sm:min-h-[600px]">
 										<!-- Front of card -->
 										<div class="absolute inset-0 backface-hidden">
+											<!-- Picture section - only on mobile, positioned above token release name -->
+											<div class="lg:hidden w-full h-48 overflow-hidden">
+												<img 
+													src={getImageUrl(assetData?.coverImage || '/images/eur-wr-cover.jpg')} 
+													alt={assetData?.name || 'Asset'}
+													loading="lazy"
+													class="w-full h-full object-cover"
+												/>
+											</div>
+											
 											<!-- Full width availability banner -->
 											<div class="{!hasAvailableSupply ? 'text-base font-extrabold text-white bg-black text-center py-3 uppercase tracking-wider' : 'text-base font-extrabold text-black bg-primary text-center py-3 uppercase tracking-wider'} w-full">
 												{hasAvailableSupply ? 'Available for Purchase' : 'Currently Sold Out'}
@@ -754,7 +774,7 @@
 													</div>
 												</div>
 											</div>
-									</div>
+										</div>
 									
 									<!-- Back of card -->
 									<div class="absolute inset-0 backface-hidden rotate-y-180 bg-white">
@@ -798,10 +818,12 @@
 											<div class="text-center py-8 text-black opacity-70">
 												<p class="text-sm">No distributions available yet.</p>
 												<p class="text-sm">First payout expected in {nextRelease?.whenRelease || 'Q1 2025'}.</p>
-																		</div>
-							{/if}
-						</div>
-					</CardContent>
+											</div>
+										{/if}
+									</div>
+								</div>
+							</div>
+						</CardContent>
 							</Card>
 						</div>
 					{/each}
@@ -842,7 +864,8 @@
 				</div>
 				</div>
 			</div>
-		</ContentSection>
+			</div>
+		</div>
 
 		<!-- Token Purchase Widget -->
 		{#if showPurchaseWidget}


### PR DESCRIPTION
Refactor asset detail page layout to optimize for mobile, moving the asset picture to token cards and hiding non-essential sections.

---

[Open in Web](https://cursor.com/agents?id=bc-b258c4da-95cf-42aa-af4c-0ca0e2cc1a25) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b258c4da-95cf-42aa-af4c-0ca0e2cc1a25) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)