### PR TITLE
Add utms to social sharing links

### DIFF
--- a/src/lib/components/patterns/assets/AssetDetailHeader.svelte
+++ b/src/lib/components/patterns/assets/AssetDetailHeader.svelte
@@ -43,7 +43,13 @@
 		if (!success) {
 			// Fallback to copying link if Web Share API fails
 			try {
-				await copyToClipboard(shareData.url);
+				// Add UTM parameters for mobile share fallback
+				const urlObj = new URL(shareData.url);
+				urlObj.searchParams.set('utm_source', 'mobile');
+				urlObj.searchParams.set('utm_medium', 'mobile_share');
+				urlObj.searchParams.set('utm_campaign', 'asset_sharing');
+				urlObj.searchParams.set('utm_content', 'social_share');
+				await copyToClipboard(urlObj.toString());
 				// You could add a toast notification here
 				alert('Link copied to clipboard!');
 			} catch (error) {
@@ -54,7 +60,13 @@
 
 	async function handleCopyLink() {
 		try {
-			await copyToClipboard(window.location.href);
+			// Add UTM parameters for copy link
+			const urlObj = new URL(window.location.href);
+			urlObj.searchParams.set('utm_source', 'direct');
+			urlObj.searchParams.set('utm_medium', 'copy_link');
+			urlObj.searchParams.set('utm_campaign', 'asset_sharing');
+			urlObj.searchParams.set('utm_content', 'social_share');
+			await copyToClipboard(urlObj.toString());
 			// You could add a toast notification here
 			alert('Link copied to clipboard!');
 		} catch (error) {

--- a/src/lib/utils/sharing.ts
+++ b/src/lib/utils/sharing.ts
@@ -8,18 +8,40 @@ export function getShareText(assetName: string): string {
   return `Unlock fractional ownership in a real-world oil field with this tokenized RWA asset: ${assetName}`;
 }
 
+// Helper function to add UTM parameters to URLs
+function addUTMParameters(url: string, medium: string, source: string = medium): string {
+  const urlObj = new URL(url);
+  urlObj.searchParams.set('utm_source', source);
+  urlObj.searchParams.set('utm_medium', medium);
+  urlObj.searchParams.set('utm_campaign', 'asset_sharing');
+  urlObj.searchParams.set('utm_content', 'social_share');
+  return urlObj.toString();
+}
+
 export function getShareUrls(shareData: ShareData) {
   const { title, text, url } = shareData;
-  const encodedUrl = encodeURIComponent(url);
+  
+  // Add UTM parameters for each platform
+  const twitterUrl = addUTMParameters(url, 'twitter', 'twitter');
+  const linkedinUrl = addUTMParameters(url, 'linkedin', 'linkedin');
+  const telegramUrl = addUTMParameters(url, 'telegram', 'telegram');
+  const whatsappUrl = addUTMParameters(url, 'whatsapp', 'whatsapp');
+  const emailUrl = addUTMParameters(url, 'email', 'email');
+  
+  const encodedTwitterUrl = encodeURIComponent(twitterUrl);
+  const encodedLinkedinUrl = encodeURIComponent(linkedinUrl);
+  const encodedTelegramUrl = encodeURIComponent(telegramUrl);
+  const encodedWhatsappUrl = encodeURIComponent(whatsappUrl);
+  const encodedEmailUrl = encodeURIComponent(emailUrl);
   const encodedText = encodeURIComponent(text);
   const encodedTitle = encodeURIComponent(title);
 
   return {
-    twitter: `https://x.com/intent/tweet?text=${encodedText}&url=${encodedUrl}`,
-    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
-    telegram: `https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`,
-    whatsapp: `https://api.whatsapp.com/send?text=${encodedText}%20${encodedUrl}`,
-    email: `mailto:?subject=${encodedTitle}&body=${encodedText}%0D%0A%0D%0A${encodedUrl}`,
+    twitter: `https://x.com/intent/tweet?text=${encodedText}&url=${encodedTwitterUrl}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedLinkedinUrl}`,
+    telegram: `https://t.me/share/url?url=${encodedTelegramUrl}&text=${encodedText}`,
+    whatsapp: `https://api.whatsapp.com/send?text=${encodedText}%20${encodedWhatsappUrl}`,
+    email: `mailto:?subject=${encodedTitle}&body=${encodedText}%0D%0A%0D%0A${encodedEmailUrl}`,
   };
 }
 


### PR DESCRIPTION
Add UTM parameters to all social sharing links to enable tracking of sharing mediums.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e1fcd71-9d06-4f60-bfe7-d09a15556e82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e1fcd71-9d06-4f60-bfe7-d09a15556e82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>