### PR TITLE
Fixes intermittent token minting failures by properly waiting for approval transaction confirmation

### DIFF
--- a/src/lib/components/patterns/TokenPurchaseWidget.svelte
+++ b/src/lib/components/patterns/TokenPurchaseWidget.svelte
@@ -347,7 +347,7 @@
 								<p class="text-sm text-gray-600 mb-2">Transaction Hash:</p>
 								<p class="text-xs font-mono text-black break-all mb-3">{transactionHash}</p>
 								<a
-									href="https://basescan.org/tx/{transactionHash}"
+									href={`https://basescan.org/tx/${transactionHash}`}
 									target="_blank"
 									rel="noopener noreferrer"
 									class="text-primary hover:text-secondary font-medium text-sm"

--- a/src/lib/components/patterns/TokenPurchaseWidget.svelte
+++ b/src/lib/components/patterns/TokenPurchaseWidget.svelte
@@ -37,6 +37,7 @@
 	let purchaseSuccess = false;
 	let purchaseError: string | null = null;
 	let canProceed = false;
+	let transactionHash: string | null = null;
 
 	// Data
 	let assetData: Asset | null = null;
@@ -177,7 +178,7 @@
 				abi: erc20Abi,
 				address: paymentToken as Hex,
 				functionName: 'allowance',
-				args: [$signerAddress as Hex, tokenAddress as Hex]
+				args: [$signerAddress as Hex, authorizerAddress as Hex]
 			});
 
 			const requiredAmount = BigInt(parseUnits(normalizedInvestmentAmount.toString(), paymentTokenDecimals));
@@ -188,7 +189,7 @@
 					abi: erc20Abi,
 					address: paymentToken as Hex,
 					functionName: 'approve',
-					args: [tokenAddress as Hex, requiredAmount]
+					args: [authorizerAddress as Hex, requiredAmount]
 				});
 
 				const approvalHash = await writeContract($wagmiConfig, approvalRequest);
@@ -212,7 +213,8 @@
 			});
 
 			// Execute deposit transaction
-			await writeContract($wagmiConfig, depositRequest);
+			const depositHash = await writeContract($wagmiConfig, depositRequest);
+			transactionHash = depositHash;
 
 			purchaseSuccess = true;
 			dispatch('purchaseSuccess', {
@@ -241,6 +243,7 @@
 		purchasing = false;
 		purchaseSuccess = false;
 		purchaseError = null;
+		transactionHash = null;
 		assetData = null;
 		tokenData = null;
 		supply = null;
@@ -339,6 +342,20 @@
 						<div class={successIconClasses}>✓</div>
 						<h3 class={successTitleClasses}>Purchase Successful!</h3>
 						<p class={successTextClasses}>You have successfully purchased <FormattedNumber value={order.tokens} type="token" /> tokens.</p>
+						{#if transactionHash}
+							<div class="mt-6 p-4 bg-light-gray rounded">
+								<p class="text-sm text-gray-600 mb-2">Transaction Hash:</p>
+								<p class="text-xs font-mono text-black break-all mb-3">{transactionHash}</p>
+								<a
+									href="https://basescan.org/tx/{transactionHash}"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="text-primary hover:text-secondary font-medium text-sm"
+								>
+									View on Basescan →
+								</a>
+							</div>
+						{/if}
 					</div>
 				{:else if purchaseError}
 					<!-- Error State -->

--- a/src/lib/components/patterns/TokenPurchaseWidget.svelte
+++ b/src/lib/components/patterns/TokenPurchaseWidget.svelte
@@ -177,7 +177,7 @@
 				abi: erc20Abi,
 				address: paymentToken as Hex,
 				functionName: 'allowance',
-				args: [$signerAddress as Hex, authorizerAddress as Hex]
+				args: [$signerAddress as Hex, tokenAddress as Hex]
 			});
 
 			const requiredAmount = BigInt(parseUnits(normalizedInvestmentAmount.toString(), paymentTokenDecimals));
@@ -188,15 +188,19 @@
 					abi: erc20Abi,
 					address: paymentToken as Hex,
 					functionName: 'approve',
-					args: [authorizerAddress as Hex, requiredAmount]
+					args: [tokenAddress as Hex, requiredAmount]
 				});
 
 				const approvalHash = await writeContract($wagmiConfig, approvalRequest);
-				
-				// Wait for approval transaction to be confirmed
+
+				// Wait for approval transaction to be confirmed with 2 block confirmations
 				await waitForTransactionReceipt($wagmiConfig, {
-					hash: approvalHash
+					hash: approvalHash,
+					confirmations: 2
 				});
+
+				// Small delay to ensure RPC nodes have synced the state
+				await new Promise(resolve => setTimeout(resolve, 1000));
 			}
 
 			// Simulate deposit transaction

--- a/src/lib/components/patterns/assets/AssetOverviewTab.svelte
+++ b/src/lib/components/patterns/assets/AssetOverviewTab.svelte
@@ -7,7 +7,7 @@
 
 export let asset: Asset;
 export let onLocationClick: (() => void) | undefined = undefined;
-export let primaryToken: TokenMetadata | null = undefined;
+export let primaryToken: TokenMetadata | null | undefined = undefined;
 
 	const { showTooltipWithDelay, hideTooltip, showTooltip } = useTooltip();
 

--- a/src/lib/data/transformers/sftTransformers.ts
+++ b/src/lib/data/transformers/sftTransformers.ts
@@ -268,8 +268,12 @@ function buildTokenAssetData(asset: PinnedMetadataAsset): AssetData {
   return {
     assetName: toString(asset.assetName),
     description: toString(asset.description),
-    cashflowProvider: asset.cashflowProvider ? toString(asset.cashflowProvider) : undefined,
-    cashflowStartDate: asset.cashflowStartDate ? ensureYearMonth(asset.cashflowStartDate) : undefined,
+    cashflowProvider: asset.cashflowProvider
+      ? toString(asset.cashflowProvider)
+      : undefined,
+    cashflowStartDate: asset.cashflowStartDate
+      ? ensureYearMonth(asset.cashflowStartDate)
+      : undefined,
     location: {
       state: toString(asset.location?.state),
       county: toString(asset.location?.county),

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -163,7 +163,7 @@ const PROD_ENERGY_FIELDS: EnergyField[] = [
         claims: [
           // Future claims
         ],
-      }
+      },
     ],
   },
 ];

--- a/src/lib/server/pinata.ts
+++ b/src/lib/server/pinata.ts
@@ -1,9 +1,12 @@
-import { PinataSDK } from 'pinata-web3';
-import { PRIVATE_PINATA_JWT, PRIVATE_PINATA_GATEWAY_KEY } from '$env/static/private';
-import { PUBLIC_PINATA_GATEWAY_URL } from '$env/static/public';
+import { PinataSDK } from "pinata-web3";
+import {
+  PRIVATE_PINATA_JWT,
+  PRIVATE_PINATA_GATEWAY_KEY,
+} from "$env/static/private";
+import { PUBLIC_PINATA_GATEWAY_URL } from "$env/static/public";
 
 export const pinata = new PinataSDK({
-	pinataJwt: PRIVATE_PINATA_JWT,
-	pinataGateway: PUBLIC_PINATA_GATEWAY_URL,
-	pinataGatewayKey: PRIVATE_PINATA_GATEWAY_KEY
+  pinataJwt: PRIVATE_PINATA_JWT,
+  pinataGateway: PUBLIC_PINATA_GATEWAY_URL,
+  pinataGatewayKey: PRIVATE_PINATA_GATEWAY_KEY,
 });

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -106,7 +106,7 @@ export function renderMarkdown(markdown: string): string {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   let html = "";
   let paragraphBuffer: string[] = [];
-  let listStack: Array<{ type: "ul" | "ol"; indent: number }> = [];
+  const listStack: Array<{ type: "ul" | "ol"; indent: number }> = [];
   let inBlockquote = false;
   let tableBuffer: string[] = [];
   let htmlTableBuffer: string[] = [];

--- a/src/routes/api/ipfs/[...path]/+server.ts
+++ b/src/routes/api/ipfs/[...path]/+server.ts
@@ -1,28 +1,31 @@
-import type { RequestHandler } from './$types';
-import { error } from '@sveltejs/kit';
-import { pinata } from '$lib/server/pinata';
+import type { RequestHandler } from "./$types";
+import { error } from "@sveltejs/kit";
+import { pinata } from "$lib/server/pinata";
 
 // Simple in-memory cache to reduce gateway requests
-const cache = new Map<string, { body: Uint8Array; contentType: string; timestamp: number }>();
+const cache = new Map<
+  string,
+  { body: Uint8Array; contentType: string; timestamp: number }
+>();
 const CACHE_TTL = 1000 * 60 * 60; // 1 hour
 
 export const GET: RequestHandler = async ({ params, setHeaders }) => {
   const { path } = params;
 
   if (!path) {
-    throw error(400, 'Path is required');
+    throw error(400, "Path is required");
   }
 
   // Check cache first
   const cached = cache.get(path);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
     setHeaders({
-      'Content-Type': cached.contentType,
-      'Cache-Control': 'public, max-age=31536000, immutable',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      'X-Cache': 'HIT',
+      "Content-Type": cached.contentType,
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+      "X-Cache": "HIT",
     });
     return new Response(cached.body);
   }
@@ -30,25 +33,30 @@ export const GET: RequestHandler = async ({ params, setHeaders }) => {
   try {
     // Use Pinata SDK to get the file
     const data = await pinata.gateways.get(path);
-    
+
     // Pinata SDK returns { data: string, contentType: string } format
-    let actualData: any;
-    let contentType = 'application/octet-stream';
-    
-    if (data && typeof data === 'object' && 'data' in data && 'contentType' in data) {
+    let actualData: unknown;
+    let contentType = "application/octet-stream";
+
+    if (
+      data &&
+      typeof data === "object" &&
+      "data" in data &&
+      "contentType" in data
+    ) {
       // Pinata SDK response format
       actualData = data.data;
-      contentType = data.contentType || 'application/octet-stream';
+      contentType = data.contentType || "application/octet-stream";
     } else {
       // Fallback for other response types
       actualData = data;
-      if (typeof data === 'string') {
-        contentType = 'text/plain';
-      } else if (data && typeof data === 'object') {
-        contentType = 'application/json';
+      if (typeof data === "string") {
+        contentType = "text/plain";
+      } else if (data && typeof data === "object") {
+        contentType = "application/json";
       }
     }
-    
+
     // Handle the response - convert to ArrayBuffer
     let body: Uint8Array;
     if (actualData instanceof Uint8Array) {
@@ -57,12 +65,12 @@ export const GET: RequestHandler = async ({ params, setHeaders }) => {
       body = new Uint8Array(actualData);
     } else if (actualData instanceof Blob) {
       body = new Uint8Array(await actualData.arrayBuffer());
-    } else if (typeof actualData === 'string') {
+    } else if (typeof actualData === "string") {
       body = new TextEncoder().encode(actualData);
     } else {
       // Stringify objects that aren't already strings
       body = new TextEncoder().encode(JSON.stringify(actualData));
-      contentType = 'application/json';
+      contentType = "application/json";
     }
 
     // Cache the response
@@ -79,23 +87,26 @@ export const GET: RequestHandler = async ({ params, setHeaders }) => {
     }
 
     setHeaders({
-      'Content-Type': contentType,
-      'Cache-Control': 'public, max-age=31536000, immutable',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      'X-Cache': 'MISS',
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+      "X-Cache": "MISS",
     });
 
     return new Response(body);
   } catch (err) {
-    console.error('IPFS proxy error:', err);
-    
-    if (err && typeof err === 'object' && 'status' in err) {
+    console.error("IPFS proxy error:", err);
+
+    if (err && typeof err === "object" && "status" in err) {
       throw err;
     }
-    
-    throw error(503, 'Failed to fetch from Pinata gateway. Please try again later.');
+
+    throw error(
+      503,
+      "Failed to fetch from Pinata gateway. Please try again later.",
+    );
   }
 };
 
@@ -103,32 +114,32 @@ export const HEAD: RequestHandler = async ({ params }) => {
   const { path } = params;
 
   if (!path) {
-    throw error(400, 'Path is required');
+    throw error(400, "Path is required");
   }
 
   try {
     // Check if file exists in cache
     const cached = cache.get(path);
-    const contentType = cached?.contentType || 'application/octet-stream';
+    const contentType = cached?.contentType || "application/octet-stream";
 
     return new Response(null, {
       status: 200,
       headers: {
-        'Content-Type': contentType,
-        'Cache-Control': 'public, max-age=31536000, immutable',
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
       },
     });
   } catch (err) {
-    console.error('IPFS proxy error:', err);
-    
-    if (err && typeof err === 'object' && 'status' in err) {
+    console.error("IPFS proxy error:", err);
+
+    if (err && typeof err === "object" && "status" in err) {
       throw err;
     }
-    
-    throw error(500, 'Failed to fetch from IPFS gateway');
+
+    throw error(500, "Failed to fetch from IPFS gateway");
   }
 };
 
@@ -136,9 +147,9 @@ export const OPTIONS: RequestHandler = async () => {
   return new Response(null, {
     status: 204,
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
     },
   });
 };

--- a/static/token_terms/0x1d57246fd0ba134d7cc78ddf3ed829379d95f4b7.md
+++ b/static/token_terms/0x1d57246fd0ba134d7cc78ddf3ed829379d95f4b7.md
@@ -4,22 +4,22 @@ _October 2025_
 
 ## PARTICULARS
 
-| Name | Value |
-| --- | --- |
-| Royalty Token Release | 1 |
-| Royalty Originator | Europa means Europa Oil & Gas Ltd, a company incorporated in England and Wales with company number 03093716 with a registered office at 54 Charlotte Street, London W1T 2NS, England |
-| Royalty Provider | Albion Labs Canada Ltd, a company incorporated in Alberta, Canada with Alberta Corporate Access Number 2027126354 whose registered office is 1500-850 2 ST SW, Calgary, Alberta, T2P0R8, Canada |
-| Issuer | S01 Issuer GmbH, registered with the commercial register of the local court Charlottenburg (Berlin) under registration number No. 270925 B |
-| Oil Field | Wressle oil field, located onshore in licence PEDL180, East Midlands Basin, United Kingdom |
-| Oil Well | Wressle Well # 1 |
-| Royalty Interest | 4.5% of Gross Revenue |
-| Royalty Payment Percentage | 7.5% of Royalty Interest |
-| Royalty Token Price | 1 USDT |
-| Payment Token Exclusive | False |
-| Supply Type | Variable Royalty Token |
-| Supply Limit | 36,000 |
-| Market Rules | AIM |
-| Management Fees | False |
+| Name                       | Value                                                                                                                                                                                           |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Royalty Token Release      | 1                                                                                                                                                                                               |
+| Royalty Originator         | Europa means Europa Oil & Gas Ltd, a company incorporated in England and Wales with company number 03093716 with a registered office at 54 Charlotte Street, London W1T 2NS, England            |
+| Royalty Provider           | Albion Labs Canada Ltd, a company incorporated in Alberta, Canada with Alberta Corporate Access Number 2027126354 whose registered office is 1500-850 2 ST SW, Calgary, Alberta, T2P0R8, Canada |
+| Issuer                     | S01 Issuer GmbH, registered with the commercial register of the local court Charlottenburg (Berlin) under registration number No. 270925 B                                                      |
+| Oil Field                  | Wressle oil field, located onshore in licence PEDL180, East Midlands Basin, United Kingdom                                                                                                      |
+| Oil Well                   | Wressle Well # 1                                                                                                                                                                                |
+| Royalty Interest           | 4.5% of Gross Revenue                                                                                                                                                                           |
+| Royalty Payment Percentage | 7.5% of Royalty Interest                                                                                                                                                                        |
+| Royalty Token Price        | 1 USDT                                                                                                                                                                                          |
+| Payment Token Exclusive    | False                                                                                                                                                                                           |
+| Supply Type                | Variable Royalty Token                                                                                                                                                                          |
+| Supply Limit               | 36,000                                                                                                                                                                                          |
+| Market Rules               | AIM                                                                                                                                                                                             |
+| Management Fees            | False                                                                                                                                                                                           |
 
 ## TERMS
 
@@ -32,6 +32,7 @@ These terms and conditions (the "**Token Terms**") are applicable to the Royalty
 You represent that you are at least the age of majority in your jurisdiction and have the full right, power, and authority to enter into and comply with the terms and conditions of these Token Terms on behalf of yourself and any company or legal entity for which you may act. If you are entering into these Token Terms on behalf of an entity, you represent to us that you have the legal authority to bind such entity.
 
 You further represent that you are not:
+
 1. the subject of economic or trade sanctions administered or enforced by any governmental authority or otherwise designated on any list of prohibited or restricted parties; or
 2. a citizen, resident, or organized in a jurisdiction or territory that is the subject of comprehensive country-wide, territory-wide, or regional economic sanctions.
 
@@ -40,6 +41,7 @@ Finally, you represent that you will fully comply with all applicable laws and r
 ## 1. Interpretation Principles
 
 In these Token Terms, unless the context otherwise requires:
+
 1. references to these Token Terms shall include any schedules to it and references to clauses, subclauses and any schedules are to clauses of, sub-clauses of, and any schedules to these Token Terms;
 2. the singular includes the plural and vice versa;
 3. "person" denotes any person, partnership, corporation or other association of whatever nature;
@@ -52,29 +54,29 @@ In these Token Terms, unless the context otherwise requires:
 
 1. In order to purchase and/or redeem Royalty Tokens from Issuer, a successful onboarding of Investor and completion of the KYC AML Requirements by Investor, including the provision of all required data and confirmation of eligibility, is required.
 2. Eligible to purchase and/or redeem Royalty Tokens are all natural and legal persons as well as partnerships with a legal personality if they fulfil the following requirements:
-    1. Investor is neither a citizen of nor does possess a permanent residence or working permit for the United States of America (USA), Canada, China, Australia or Iran and has no residence or registered office within the territory of one of these states;
-    2. Investor is not a corporation or other entity organized under federal or any state law of the USA or under the comparable law of Canada, China, Australia or Iran of which the income is subject to the law of one of the aforementioned jurisdictions; and
-    3. neither Investor nor Investor's Wallet is listed on neither one of the European Union's nor on one of the United States of America's respective sanction lists.
+   1. Investor is neither a citizen of nor does possess a permanent residence or working permit for the United States of America (USA), Canada, China, Australia or Iran and has no residence or registered office within the territory of one of these states;
+   2. Investor is not a corporation or other entity organized under federal or any state law of the USA or under the comparable law of Canada, China, Australia or Iran of which the income is subject to the law of one of the aforementioned jurisdictions; and
+   3. neither Investor nor Investor's Wallet is listed on neither one of the European Union's nor on one of the United States of America's respective sanction lists.
 3. The following information is required for onboarding if Investor is a natural person:
-    1. all names and surnames of Investor;
-    2. the declared place of residence including the complete address;
-    3. Investor's date of birth;
-    4. Investor's place of birth;
-    5. the nationality of Investor;
-    6. the number of an identity card or passport which has been issued by the competent authority to Investor;
-    7. an e-mail address of Investor; and
-    8. additional information may be required in enhanced due diligence processes.
+   1. all names and surnames of Investor;
+   2. the declared place of residence including the complete address;
+   3. Investor's date of birth;
+   4. Investor's place of birth;
+   5. the nationality of Investor;
+   6. the number of an identity card or passport which has been issued by the competent authority to Investor;
+   7. an e-mail address of Investor; and
+   8. additional information may be required in enhanced due diligence processes.
 4. The following information is required for onboarding if Investor is an entity or a partnership with a legal personality:
-    1. complete legal form of Investor;
-    2. statutory, or where applicable, the place of business of Investor as registered in a public registry including the complete address;
-    3. (if existing) Investor's registry number from the commercial registry or a comparable public registry;
-    4. name of the statutory authorized representative or representatives of Investor;
-    5. an e-mail address of Investor; and 
-    6. additional information may be required in enhanced due diligence processes.
+   1. complete legal form of Investor;
+   2. statutory, or where applicable, the place of business of Investor as registered in a public registry including the complete address;
+   3. (if existing) Investor's registry number from the commercial registry or a comparable public registry;
+   4. name of the statutory authorized representative or representatives of Investor;
+   5. an e-mail address of Investor; and
+   6. additional information may be required in enhanced due diligence processes.
 5. As part of the onboarding process, Investor is asked to name a Blockchain Wallet address to which the Royalty Tokens can be transferred after successful completion of the onboarding process. Investors may be asked to provide confirmation of ownership or control of the Wallet. A Wallet screen may be conducted as part of the onboarding process.
 6. For the onboarding to be successful it is required that the information provided by Investor is:
-    1. complete; and
-    2. that there is no indication that Investor provided incorrect data.
+   1. complete; and
+   2. that there is no indication that Investor provided incorrect data.
 7. Issuer is entitled but not obligated to audit the data provided during the onboarding process by a qualified third party.
 8. Issuer notifies Investor if the onboarding and the completion of the KYC AML Requirements was successful. The respective Investor is then considered as Greenlisted.
 9. Investor is obligated to notify Issuer immediately if any of the information provided has changed.
@@ -86,8 +88,8 @@ In these Token Terms, unless the context otherwise requires:
 3. Royalty Tokens may be subscribed for as part of specific Royalty Token Releases by submitting a purchase application to Issuer via the designated Interface. Investor must specify the intended subscription amount, provide a compatible Blockchain Wallet address and pay the applicable Royalty Token Price before the Royalty Tokens are transferred.
 4. The economic parameters applicable to each Royalty Token Release, including the underlying asset, Royalty Interest, Royalty Payment Percentage, Royalty Token Price, Supply Type, Supply Limit, and, if applicable, Management Fees, are set out in the Particulars table for each Release. These Particulars are made available to Investors via the system Interface.
 5. Each Royalty Token Release is a type of Royalty Token, either:
-    1. a Fixed Royalty Token; or
-    2. a Variable Royalty Token.
+   1. a Fixed Royalty Token; or
+   2. a Variable Royalty Token.
 6. Royalty Tokens are transferred to Investor after full payment of the Royalty Token Price to the Wallet address provided by Investor. Payment must be made in the currency specified in the applicable Particulars for that Royalty Token Release.
 7. Issuance of Royalty Tokens is permitted only for Investors who have successfully completed the onboarding process and are considered Greenlisted by Issuer.
 
@@ -97,19 +99,19 @@ In these Token Terms, unless the context otherwise requires:
 2. Investors are entitled to receive pro-rata Distributions from Issuer, which reflect Revenue Payments received by Issuer under the Revenue Purchase Agreement. These Revenue Payments result from Royalty Payments made by Royalty Originator to Royalty Provider under the Revenue Swap Agreement. These Total Distributions are determined based on the Royalty Interest acquired by Issuer under the applicable Revenue Purchase Agreement and the Royalty Payment Percentage specified for the relevant Royalty Token Release. Any such Distributions shall only become due and payable by Issuer to Investors upon actual receipt of the corresponding Total Distributions as Revenue Payments from Royalty Provider.
 3. To the extent that interest is payable by Royalty Originator in connection with delayed or outstanding Royalty Payments under the Revenue Swap Agreement and such amounts are acquired by Issuer as Revenue Payments under the Revenue Purchase Agreement, such interest shall be treated as part of the Total Distributions and distributed by Issuer to Investors accordingly.
 4. Distributions to Investors for both Supply Types (Fixed or Variable) are calculated based on the following steps.
-    1. Royalty Interest including increases or reductions (minus fees of Royalty Provider), split between Royalty Token Releases according to the Royalty Payment Percentages, to get the Total Distribution.
-    2. Total Distribution divided by the quantity of Royalty Tokens minted for the applicable Royalty Token Release to get the payment per Royalty Token held by an Investor during a month, which is determined by reference to the Snapshot process described by the clause at reference 2.
+   1. Royalty Interest including increases or reductions (minus fees of Royalty Provider), split between Royalty Token Releases according to the Royalty Payment Percentages, to get the Total Distribution.
+   2. Total Distribution divided by the quantity of Royalty Tokens minted for the applicable Royalty Token Release to get the payment per Royalty Token held by an Investor during a month, which is determined by reference to the Snapshot process described by the clause at reference 2.
 5. For Fixed Royalty Tokens, Distributions are calculated as an equal share of the Total Distribution allocated to the corresponding Royalty Token Release based on the fixed number of Tokens defined as the Supply Limit in the Particulars. Each Royalty Token represents a fixed portion of the Total Distribution for that Royalty Token Release.
 6. For Variable Royalty Tokens, Distributions are calculated based on the number of Royalty Tokens in circulation at the time of the Snapshots and the number of Royalty Tokens held in Investor's Wallet. Variable Royalty Tokens are minted progressively upon acquisition by Investors from Issuer until the Supply Limit specified in the Particulars is reached.
 7. Where a portion of the Revenue Payment is not allocated to an active Royalty Token Release, it will be retained as Pending Distributions and distributed to Investors on a pro-rata basis in accordance with the Royalty Payment Percentage over the first twelve (12) Distribution cycles of the relevant Royalty Token Release.
-8. Distributions are determined based on two blockchain Snapshots taken per calendar day by Issuer, without prior notice. These Snapshots record for each Royalty Token Release: 
-    1. Wallet Balance; and
-    2. Release Supply.
+8. Distributions are determined based on two blockchain Snapshots taken per calendar day by Issuer, without prior notice. These Snapshots record for each Royalty Token Release:
+   1. Wallet Balance; and
+   2. Release Supply.
 9. For each Distribution cycle, to calculate the percentage of the Total Distribution for payment to a Wallet, Issuer will determine the average of the Wallet Balance and Release Supply between the Snapshots and use the following formula: average Wallet Balance divided by average Release Supply multiplied by 100. |Ref 2|
 10. Investors must hold Royalty Tokens at the time of at least one of the Snapshots in order to be eligible for a Distribution in the relevant month. The Distribution amount is then calculated as described in the clause at reference 2. No Distributions are made to a Wallet if the Token is not held by a Wallet in either Snapshot. |Ref 3|
 11. In the event that Royalty Payments under the Revenue Swap Agreement are temporarily suspended and subsequently recommence, Distributions to Investors shall be calculated based on the Snapshots taken during the period of suspension. This applies only if such Snapshots were validly recorded by Issuer in accordance with the clause at reference 3 and ensures that Distribution rights accrued during the suspension are preserved upon recommencement of Revenue Payments.
 12. Distributions are made through an on-chain Vault mechanism. Issuer will deposit the relevant Total Distribution into the relevant Vault within 5 Business Days following receipt of the Total Distribution. Investors are responsible for claiming their Distributions by connecting their Wallet to the system Interface, which generates Crypto Receipts and shows amounts available for claim by Investor. Any transaction fees incurred in the course of claiming are borne by Investor.
-13. Distributions must be claimed by Investor within a period of three (3) years from the date on which the Distribution was first made available in the on-chain Vault. After this period, any unclaimed amounts may be withdrawn from the Vault and retained by Issuer or a designated third party. The limitation period shall be suspended if Investor was evidently prevented, without fault, from claiming the Distribution. This does not affect Investor's statutory rights in case of technical errors or legal disputes concerning entitlement. 
+13. Distributions must be claimed by Investor within a period of three (3) years from the date on which the Distribution was first made available in the on-chain Vault. After this period, any unclaimed amounts may be withdrawn from the Vault and retained by Issuer or a designated third party. The limitation period shall be suspended if Investor was evidently prevented, without fault, from claiming the Distribution. This does not affect Investor's statutory rights in case of technical errors or legal disputes concerning entitlement.
 14. If indicated in the Particulars, Management Fees may apply and will be deducted from the Total Distribution before payment to Investors.
 15. A summary of the key terms of the:
     1. Framework Revenue Purchase Agreement is the Framework Revenue Purchase Agreement Summary (Schedule 2); and
@@ -118,43 +120,43 @@ In these Token Terms, unless the context otherwise requires:
 ## 5. Disruption of Royalty Payments
 
 1. Investor's entitlement to future Distributions under a Royalty Token Release may be temporarily suspended, delayed, proportionally reduced or permanently ceased, in whole or in part, if circumstances beyond the control of Issuer materially affect the accrual, calculation or legal enforceability of the underlying Royalty Payments from Royalty Originator to Royalty Provider and / or Revenue Payments from Royalty Provider to Issuer, and / or Total Distributions from Royalty Provider to Issuer. Such circumstances include, but are not limited to:
-    1. operational disruptions or technical failure at the Oil Well, including breakdowns or production stoppages;
-    2. economic or technical depletion of the Wellbore, including side-tracking, cessation of production or additional capital expenditure by Royalty Originator;
-    3. suspension, termination, expiry or non-renewal of the Project Agreement, the Offtake Agreement, the Revenue Swap Agreement or the Government Licence;
-    4. failure by Royalty Originator to make Royalty Payments to Royalty Provider, including partial or delayed payments;
-    5. breach of contract, non-performance or an Insolvency Event affecting Royalty Originator, Royalty Provider or any other material contractual party;
-    6. failure or disruption involving third-party service providers essential to Royalty operations, including subcontractors, payment processors or banking;
-    7. governmental action or regulatory intervention (e.g., licence revocation or changes in tax, civil or regulatory frameworks) that make continued performance legally or economically unfeasible;
-    8. drastic market developments (e.g., oil price volatility or adverse currency fluctuations) materially affecting Royalty revenue;
-    9. transfer or assumption of Royalty Originator's interest under the Project Agreement that materially impacts the performance of the Royalty;
-    10. administrative, management or tax costs exceeding the expected value of Royalty Payments;
-    11. in the event of Force Majeure; and
-    12. security-related events including hacking, fraud, or systemic blockchain vulnerabilities leading to necessary freezing of the Royalty Token functionality or vault access.
+   1. operational disruptions or technical failure at the Oil Well, including breakdowns or production stoppages;
+   2. economic or technical depletion of the Wellbore, including side-tracking, cessation of production or additional capital expenditure by Royalty Originator;
+   3. suspension, termination, expiry or non-renewal of the Project Agreement, the Offtake Agreement, the Revenue Swap Agreement or the Government Licence;
+   4. failure by Royalty Originator to make Royalty Payments to Royalty Provider, including partial or delayed payments;
+   5. breach of contract, non-performance or an Insolvency Event affecting Royalty Originator, Royalty Provider or any other material contractual party;
+   6. failure or disruption involving third-party service providers essential to Royalty operations, including subcontractors, payment processors or banking;
+   7. governmental action or regulatory intervention (e.g., licence revocation or changes in tax, civil or regulatory frameworks) that make continued performance legally or economically unfeasible;
+   8. drastic market developments (e.g., oil price volatility or adverse currency fluctuations) materially affecting Royalty revenue;
+   9. transfer or assumption of Royalty Originator's interest under the Project Agreement that materially impacts the performance of the Royalty;
+   10. administrative, management or tax costs exceeding the expected value of Royalty Payments;
+   11. in the event of Force Majeure; and
+   12. security-related events including hacking, fraud, or systemic blockchain vulnerabilities leading to necessary freezing of the Royalty Token functionality or vault access.
 2. In such cases, Issuer will inform Investors via the system Interface without undue delay, where feasible, and may apply one or more of the following remedial measures:
-    1. temporary suspension of Distributions with the possibility of subsequent catch-up; such catch-up payments shall be made exclusively to those Investors who, according to the Snapshot data, held the relevant Royalty Tokens during the period in which the Revenue Payment is not received by Issuer, in proportion to their Wallet Balance recorded at the relevant Snapshot dates; where the Total Distributions actually received by Issuer for the relevant period is lower than the Total Distribution originally due, the catch-up payments will make up the difference relative to the originally due Total Distribution;
-    2. permanent cessation of Distributions, if the underlying Royalty entitlement has definitively ceased or cannot reasonably be expected to resume due to legal, operational or economic reasons;
-    3. pro-rata allocation of any alternative settlement or negotiated outcome between Royalty Provider and Royalty Originator to Investors, based on the Wallet Balance recorded for each Investor at the relevant Snapshot dates during the period in which the underlying Revenue Payment is not received by Issuer; if the total amount actually received by Royalty Provider under such settlement or negotiated outcome is lower than the aggregate Total Distribution originally due for that period, the amount allocable to each Investor shall be reduced in the same proportion as the total settlement amount bears to the aggregate originally due Total Distribution;
-    4. application of Pending Distributions, if available, to offset temporary shortfalls in Distributions;
-    5. resumption of Distributions, if applicable, based on the Snapshot balances recorded during the suspension period, unless otherwise determined in accordance with the Token Terms.
+   1. temporary suspension of Distributions with the possibility of subsequent catch-up; such catch-up payments shall be made exclusively to those Investors who, according to the Snapshot data, held the relevant Royalty Tokens during the period in which the Revenue Payment is not received by Issuer, in proportion to their Wallet Balance recorded at the relevant Snapshot dates; where the Total Distributions actually received by Issuer for the relevant period is lower than the Total Distribution originally due, the catch-up payments will make up the difference relative to the originally due Total Distribution;
+   2. permanent cessation of Distributions, if the underlying Royalty entitlement has definitively ceased or cannot reasonably be expected to resume due to legal, operational or economic reasons;
+   3. pro-rata allocation of any alternative settlement or negotiated outcome between Royalty Provider and Royalty Originator to Investors, based on the Wallet Balance recorded for each Investor at the relevant Snapshot dates during the period in which the underlying Revenue Payment is not received by Issuer; if the total amount actually received by Royalty Provider under such settlement or negotiated outcome is lower than the aggregate Total Distribution originally due for that period, the amount allocable to each Investor shall be reduced in the same proportion as the total settlement amount bears to the aggregate originally due Total Distribution;
+   4. application of Pending Distributions, if available, to offset temporary shortfalls in Distributions;
+   5. resumption of Distributions, if applicable, based on the Snapshot balances recorded during the suspension period, unless otherwise determined in accordance with the Token Terms.
 3. Investor acknowledges that the Royalty and consequently any Royalty Payments and Distributions are strictly limited to the revenue generated from the original Wellbore as specified in the relevant Royalty Token Release. If Royalty Originator undertakes new capital expenditures (e.g. sidetracking, drilling of new wells or modifying the existing Wellbore), the Royalty is very unlikely to extend to the resulting new production. In such cases, Royalty Payments under the terms of the existing Revenue Swap Agreement may cease without any entitlement to participate in revenues from future production.
 
 ## 6. Termination for Good Cause
 
 1. Ordinary termination rights are excluded.
 2. Either Party may terminate the contractual relationship underlying these Token Terms with immediate effect for good cause (extraordinary termination), provided that the terminating Party cannot reasonably be expected to continue the contractual relationship under the given circumstances. A good cause shall be deemed to exist in particular, but not exclusively, in the following cases:
-    1. an Insolvency Event relating to Issuer, Royalty Originator or Royalty Provider occurs;
-    2. the underlying Revenue Swap Agreement or any other fundamental contractual arrangement essential to the operation and entitlement of the Royalty, such as the Government Licence or the Offtake Agreement, is terminated, expires or becomes legally or factually unenforceable on a permanent basis;
-    3. a change in applicable law, tax regulation or regulatory interpretation occurs that makes it legally or economically impossible or unreasonable to continue the Royalty structure or for Issuer to make further Distributions; or
-    4. one of the Parties commits a material breach of its contractual obligations and fails to remedy such breach within a reasonable grace period, if applicable, and the non-breaching Party cannot reasonably be expected to continue the contractual relationship.
+   1. an Insolvency Event relating to Issuer, Royalty Originator or Royalty Provider occurs;
+   2. the underlying Revenue Swap Agreement or any other fundamental contractual arrangement essential to the operation and entitlement of the Royalty, such as the Government Licence or the Offtake Agreement, is terminated, expires or becomes legally or factually unenforceable on a permanent basis;
+   3. a change in applicable law, tax regulation or regulatory interpretation occurs that makes it legally or economically impossible or unreasonable to continue the Royalty structure or for Issuer to make further Distributions; or
+   4. one of the Parties commits a material breach of its contractual obligations and fails to remedy such breach within a reasonable grace period, if applicable, and the non-breaching Party cannot reasonably be expected to continue the contractual relationship.
 3. The extraordinary termination must be declared in text form (e.g. via the Interface or email). Termination shall not affect any claims that have already arisen prior to the effective date of termination, particularly any pending or accrued Distributions.
 
 ## 7. Issuer Rights |Ref 4|
 
 1. In the event of a Security Event Issuer shall have the right, at its sole and reasonable discretion, to take any of the following remedial measures to protect the integrity of the Royalty Token system, subject to applicable law and with due regard to the interests of Investors:
-    1. Issuer may suspend all transactions involving the affected SFT Bucket, including minting, burning and transfers of Tokens, until the risk has been resolved or mitigated. As part of this measure, Issuer may activate a smart contract-based freeze function to technically enforce the suspension of all Royalty Token activity. During the freeze, Investors will not be able to transfer, acquire or otherwise dispose of their Royalty Tokens. The freeze shall be lifted once the relevant risk has been assessed and mitigated.
-    2. Issuer may deploy a new SFT Bucket to replace the affected smart contract infrastructure. In this case, Issuer may distribute new replacement Royalty Tokens via airdrop to Investors recorded in a Snapshot prior to the Security Event or establish a swap mechanism allowing Investors to voluntarily exchange old Royalty Tokens for new ones.
-    3. To preserve the legal and economic integrity of the Royalty Token system and to avoid unjust enrichment of malicious actors, Issuer shall have the sole and absolute discretion to exclude any Wallets that are, directly or indirectly connected with the Security Event from participating in any Royalty Token airdrop or other remedial measure under this section at reference 4.
-    4. This section at reference 4 shall not limit Issuer’s liability for intent, gross negligence or damages resulting from injury to life, body or health. The discretionary powers granted to Issuer herein shall be exercised in good faith and in a manner that is reasonable, transparent and proportionate to the nature of the Security Event.
+   1. Issuer may suspend all transactions involving the affected SFT Bucket, including minting, burning and transfers of Tokens, until the risk has been resolved or mitigated. As part of this measure, Issuer may activate a smart contract-based freeze function to technically enforce the suspension of all Royalty Token activity. During the freeze, Investors will not be able to transfer, acquire or otherwise dispose of their Royalty Tokens. The freeze shall be lifted once the relevant risk has been assessed and mitigated.
+   2. Issuer may deploy a new SFT Bucket to replace the affected smart contract infrastructure. In this case, Issuer may distribute new replacement Royalty Tokens via airdrop to Investors recorded in a Snapshot prior to the Security Event or establish a swap mechanism allowing Investors to voluntarily exchange old Royalty Tokens for new ones.
+   3. To preserve the legal and economic integrity of the Royalty Token system and to avoid unjust enrichment of malicious actors, Issuer shall have the sole and absolute discretion to exclude any Wallets that are, directly or indirectly connected with the Security Event from participating in any Royalty Token airdrop or other remedial measure under this section at reference 4.
+   4. This section at reference 4 shall not limit Issuer’s liability for intent, gross negligence or damages resulting from injury to life, body or health. The discretionary powers granted to Issuer herein shall be exercised in good faith and in a manner that is reasonable, transparent and proportionate to the nature of the Security Event.
 2. Issuer is entitled to upgrade the functionality of the Royalty Token, in particular to improve security, efficiency or regulatory compliance. For this purpose, Issuer may provide a 1:1 swap mechanism via a smart contract, allowing Investors to voluntarily exchange their existing Royalty Tokens for new Royalty Tokens with updated functionality. The existing rights associated with the Royalty Token shall remain unaffected until the swap is executed such that the terms of the new Royalty Tokens will come into effect between the Parties and the agreement represented by the old Royalty Token will be terminated immediately.
 3. Issuer may, upon receipt of a binding and enforceable order issued by a competent legal authority with jurisdiction, confiscate Royalty Tokens held by an Investor if such measure is strictly required to comply with applicable laws or regulations (including but not limited to sanctions, anti-money laundering obligations, or court orders). In such case, the relevant Royalty Tokens may be transferred to a designated wallet specified by the authority or technically restricted (e.g., via freezing or blocking of transfers). Issuer shall notify the affected Investor of the measure and the underlying legal basis without undue delay, unless prohibited by law. If such action is later found to have been erroneous or unlawful, Investor shall be entitled to appropriate restitution or restoration of their Royalty Token holdings, where legally and technically feasible. Any confiscation without legal basis or compensation is expressly excluded. All other rights of Investor under these Token Terms remain unaffected.
 
@@ -170,12 +172,12 @@ In these Token Terms, unless the context otherwise requires:
 ## 9. Token Rights and Transfer
 
 1. The Royalty Token does not grant Investor any ownership, co-ownership or property rights in the underlying Royalty, the Revenue Swap Agreement or the associated energy asset. In particular:
-    1. the Royalty Token does not represent a fractional ownership interest in any receivable, asset, licence or contractual right held by Issuer or Royalty Originator;
-    2. the Royalty Token only confers a contractual right to receive a Distribution, calculated according to the rules and formulas set out in these Token Terms and the applicable Particulars based on Royalty Payments received by Issuer;
-    3. the Royalty Token carries no other rights whatsoever, including, but not limited to, voting rights, dividend rights, rights to participate in rights issues or participation in shareholder meetings.
+   1. the Royalty Token does not represent a fractional ownership interest in any receivable, asset, licence or contractual right held by Issuer or Royalty Originator;
+   2. the Royalty Token only confers a contractual right to receive a Distribution, calculated according to the rules and formulas set out in these Token Terms and the applicable Particulars based on Royalty Payments received by Issuer;
+   3. the Royalty Token carries no other rights whatsoever, including, but not limited to, voting rights, dividend rights, rights to participate in rights issues or participation in shareholder meetings.
 2. Where control over a Royalty Token is transferred by way of crypto token transfer:
-    1. the transferring Party shall be deemed to have transferred all rights and obligations associated with that Royalty Token under these Token Terms;
-    2. the owner of the transferee Wallet shall automatically become subject to these Token Terms in place of the transferor, without the need for separate consent by Issuer.
+   1. the transferring Party shall be deemed to have transferred all rights and obligations associated with that Royalty Token under these Token Terms;
+   2. the owner of the transferee Wallet shall automatically become subject to these Token Terms in place of the transferor, without the need for separate consent by Issuer.
 
 ## 10. Legal Compliance of Investors
 
@@ -187,13 +189,13 @@ In these Token Terms, unless the context otherwise requires:
 
 1. Investor bears the risk of any changes in law, regulation or tax regime, particularly the introduction of hydrocarbon-related taxes, that may reduce or eliminate Royalty Payments and, consequently, the Revenue Payments and Distributions derived therefrom. Such changes may occur without prior notice and are beyond the control of Issuer, Royalty Originator or Royalty Provider.
 2. Crypto transactions are irreversible. Investors accept the following risks associated with errors:
-    1. If a third party (e.g., an external service provider or wallet provider) makes an error, Issuer is not liable for the resulting consequences, provided such third party is not acting as a vicarious agent (Erfüllungsgehilfe) or auxiliary person (Verrichtungsgehilfe) within the meaning of Applicable Law.
-    2. If Issuer causes an error, Investor may assert claims in accordance with statutory law and the clause at reference 5 of these Token Terms.
+   1. If a third party (e.g., an external service provider or wallet provider) makes an error, Issuer is not liable for the resulting consequences, provided such third party is not acting as a vicarious agent (Erfüllungsgehilfe) or auxiliary person (Verrichtungsgehilfe) within the meaning of Applicable Law.
+   2. If Issuer causes an error, Investor may assert claims in accordance with statutory law and the clause at reference 5 of these Token Terms.
 3. Investors who acquire Royalty Tokens on the secondary market acknowledge that prior Distributions may, in rare cases, have been incorrectly calculated due to technical or administrative errors. Such errors may originate from third parties involved in the upstream payment chain, including Royalty Originator, who is not a party to the contractual relationship between Investor and Issuer. If such an error is identified after a Royalty Token has been transferred, Issuer may, to the extent legally permissible and technically feasible, adjust future Distributions to reflect the correct allocation. Such adjustment shall only apply if it does not retroactively reduce legally vested claims and shall not be made if the error was caused by Issuer’s, Royalty Provider’s or Royalty Originator’s intent or gross negligence. Issuer shall inform the affected Investors in a timely, clear, and transparent manner and shall document the reasons and method of correction.
 4. If Royalty Provider is required to initiate legal action against Royalty Originator to enforce payment of due Royalty amounts, the following shall apply:
-    1. If the enforcement is successful and funds are recovered, whether in full or in part, Royalty Provider is entitled to deduct only those legal costs that are (i) directly related to the enforcement of the Royalty Payments, (ii) objectively necessary and reasonable in amount, and (iii) supported by verifiable documentation. Any recovered amount will be transferred to Issuer for onward Distribution to Investors in accordance with these Token Terms.
-    2. If the enforcement is unsuccessful and becomes a Permanent Payment Default, Royalty Provider shall bear all legal costs. Investors shall not suffer any financial disadvantage as a result.
-    3. If the enforcement is temporarily unsuccessful but the default has not become a Permanent Payment Default, Royalty Provider may offset the incurred legal costs proportionally against future Royalty Payments or instalment amounts recovered pursuant to an agreed payment schedule between Royalty Provider and Royalty Originator, before forwarding them to Issuer for Distribution to Investors. Such offsets may only occur in the course of ongoing Distributions and may not retroactively affect prior payouts. This clause does not entitle Issuer to claim additional payments from Investors or to recover any previously distributed amounts.
+   1. If the enforcement is successful and funds are recovered, whether in full or in part, Royalty Provider is entitled to deduct only those legal costs that are (i) directly related to the enforcement of the Royalty Payments, (ii) objectively necessary and reasonable in amount, and (iii) supported by verifiable documentation. Any recovered amount will be transferred to Issuer for onward Distribution to Investors in accordance with these Token Terms.
+   2. If the enforcement is unsuccessful and becomes a Permanent Payment Default, Royalty Provider shall bear all legal costs. Investors shall not suffer any financial disadvantage as a result.
+   3. If the enforcement is temporarily unsuccessful but the default has not become a Permanent Payment Default, Royalty Provider may offset the incurred legal costs proportionally against future Royalty Payments or instalment amounts recovered pursuant to an agreed payment schedule between Royalty Provider and Royalty Originator, before forwarding them to Issuer for Distribution to Investors. Such offsets may only occur in the course of ongoing Distributions and may not retroactively affect prior payouts. This clause does not entitle Issuer to claim additional payments from Investors or to recover any previously distributed amounts.
 5. Investor shall not be entitled to derive any contractual or quasi-contractual rights or entitlements from, or assert any such rights or entitlements against, Royalty Originator based on the contractual relationship between Royalty Provider and Royalty Originator. In particular, the contractual relationship between Royalty Originator and Royalty Provider shall not give rise to any contractual or quasi-contractual rights or entitlements of Investor.
 6. The Royalty Token system operates on blockchain-based infrastructure. Technical malfunctions, software bugs, or security incidents, such as smart contract exploits, oracle failures or consensus-level attacks, may impair or interrupt the functionality of the Royalty Tokens. Issuer cannot guarantee the uninterrupted or error-free performance of blockchain networks or third-party infrastructure that is beyond their control. Issuer shall implement industry-standard security measures to safeguard assets both on-chain and off-chain. Nevertheless, Investors acknowledge that the use of crypto-based payment systems involves certain inherent risks, including but not limited to losses resulting from hacking, fraud, or technical malfunctions outside Issuer’s control. This does not affect Issuer’s liability for damages caused by intent or gross negligence, or for the slightly negligent breach of material contractual obligations (cardinal duties). Further provisions on liability are set out in the clause at reference 5 of these Token Terms.
 
@@ -201,7 +203,7 @@ In these Token Terms, unless the context otherwise requires:
 
 1. The Secured Claims of Investors shall be secured by the Collateral granted by Issuer and held by the Security Agent under the Collateral Agreement. Upon receipt by the Security Agent of a Notice Of Event Of Default and after a grace period of thirty (30) calendar days has expired and after the Security Agent has verified that an Event Of Default or an Insolvency Event in relation to Issuer has occurred, the Security Agent shall enforce and manage the Collateral for the account (under a true contract for the benefit of third parties) of Investors in accordance with the terms of the Collateral Agreement.
 2. The Security Agent shall be entitled, upon the occurrence of an Event Of Default, to enforce directly any assigned claims or enforcement rights against Royalty Provider on behalf of Investors, including by way of legal action or settlement. Issuer shall provide the Security Agent with all necessary documentation and access to information required for enforcement. Royalty Provider shall cooperate with the Security Agent in good faith and may not object to such enforcement on the basis of lacking privity of contract.
-3. The Security Agent is not a common representative of Investors within the meaning of the German Debenture Bond Act (*Schuldverschreibungsgesetz*) and it is not liable under the provisions of the German Debenture Bond Act.
+3. The Security Agent is not a common representative of Investors within the meaning of the German Debenture Bond Act (_Schuldverschreibungsgesetz_) and it is not liable under the provisions of the German Debenture Bond Act.
 4. The Security Agent shall receive from Issuer during the term of the Collateral Agreement an appropriate remuneration as well as reimbursement of its expenses, fees and disbursements incurred in connection with the Collateral Agreement.
 5. The Collateral Agreement provides that upon the occurrence of an Event Of Default or an Insolvency Event relating to Issuer the Collateral cannot be realised by Issuer. If none of these events occur, Issuer may access and realise the Collateral.
 6. By investing in the Royalty Tokens, each Investor expressly agrees and acknowledges that Issuer shall appoint the Security Agent to act on behalf of Investors for the purpose of holding and enforcing the collateral, as further specified in and subject to the terms and conditions of the Collateral Terms (Schedule 1) of the Collateral Agreement.
@@ -215,18 +217,18 @@ In these Token Terms, unless the context otherwise requires:
 3. Issuer will disclose data received from Royalty Originator by way of Royalty Provider regarding the Oil Well, once such data becomes publicly available.
 4. Before disclosing to Investors data received from Royalty Originator regarding the Oil Well, Issuer may repackage or amend the data, or omit certain details from it, as reasonably determined by Issuer, provided such repackaging, amendment or omission does not render the data inaccurate or misleading.
 5. Issuer is not obliged to disclose any information received from Royalty Originator to Investors where Issuer considers in good faith that:
-    1. such information constitutes or may constitute ‘inside information’ for the purposes of the United Kingdom’s Market Abuse Regulation, the EU Market Abuse Regulation, the Criminal Justice Act 1993, United Kingdom or under other applicable legislation (including where such legislation uses different terminology to ‘inside information’); or
-    2. disclosure of the information may breach applicable law (including laws concerning privacy or the distribution of competitively sensitive information) or an obligation of confidentiality owed to a third party. 
+   1. such information constitutes or may constitute ‘inside information’ for the purposes of the United Kingdom’s Market Abuse Regulation, the EU Market Abuse Regulation, the Criminal Justice Act 1993, United Kingdom or under other applicable legislation (including where such legislation uses different terminology to ‘inside information’); or
+   2. disclosure of the information may breach applicable law (including laws concerning privacy or the distribution of competitively sensitive information) or an obligation of confidentiality owed to a third party.
 6. Nothing in this section shall limit or exclude Issuer’s liability for injury to life, body, or health, or for damages caused by intent or gross negligence, or affect mandatory statutory liability.
 
 ## 14. Liability |Ref 5|
 
 1. Issuer shall be liable without limitation only for damages suffered by Investor that:
-    1. are caused by an intentional or grossly negligent breach of duty by Issuer its legal representatives or vicarious agents; or
-    2. result from the slightly negligent breach of a material contractual obligation (cardinal duty). In this case, Issuer’s liability shall be limited to the foreseeable damage typical for the type of contract. Cardinal duties are obligations whose fulfilment is essential for the proper execution of the Token Terms and on which Investor regularly relies.
+   1. are caused by an intentional or grossly negligent breach of duty by Issuer its legal representatives or vicarious agents; or
+   2. result from the slightly negligent breach of a material contractual obligation (cardinal duty). In this case, Issuer’s liability shall be limited to the foreseeable damage typical for the type of contract. Cardinal duties are obligations whose fulfilment is essential for the proper execution of the Token Terms and on which Investor regularly relies.
 2. Issuer shall not be liable for defects, malfunctions or failures of any blockchain, smart contracts or other technical infrastructure operated by third parties beyond their control. This includes, in particular, losses due to errors, delays, or interruptions in blockchain-based transactions. Issuer shall also not be liable for the loss of off-chain assets or on-chain tokens, unless such loss was caused by intentional misconduct or gross negligence. Liability for data loss is limited to typical recovery costs that would have been incurred with appropriate, risk-based data backup.
 3. Any further liability of Issuer is excluded to the extent permitted by law. This limitation also applies to the personal liability of their employees, representatives and vicarious agents, including liability in tort.
-4. The above exclusions and limitations of liability shall not apply in cases of injury to life, body or health, in the event of liability under mandatory statutory provisions, particularly the German Product Liability Act (*Produkthaftungsgesetz*) or where a guarantee to Investor has been expressly assumed.
+4. The above exclusions and limitations of liability shall not apply in cases of injury to life, body or health, in the event of liability under mandatory statutory provisions, particularly the German Product Liability Act (_Produkthaftungsgesetz_) or where a guarantee to Investor has been expressly assumed.
 5. The limitation period for all warranty claims of Investor shall be twelve (12) months, unless longer periods are required by mandatory law. This does not apply if Investor is a consumer within the meaning of § 13 BGB; in such cases, the statutory limitation periods shall remain unaffected.
 
 ## 15. Force Majeure
@@ -239,22 +241,23 @@ In these Token Terms, unless the context otherwise requires:
 ## 16. Substitution of Issuer
 
 Each Issuer may, without the prior consent of Investors, substitute themselves in relation to all rights and obligations under these Token Terms with another legal entity (the “New Issuer”), provided that:
+
 1. the New Issuer is objectively capable of performing all obligations arising from or in connection with these Token Terms;
 2. the existing Issuer provides an irrevocable and unconditional guarantee to Investors for the full and timely performance of the New Issuer’s obligations under these Token Terms;
 3. such substitution does not materially impair the legal position of Investors, in particular with regard to:
-    1. the enforceability of rights under these Token Terms,
-    2. the applicable regulatory protections, and
-    3. Investor's ability to receive Distributions.
+   1. the enforceability of rights under these Token Terms,
+   2. the applicable regulatory protections, and
+   3. Investor's ability to receive Distributions.
 
 Investors shall be informed of any substitution without undue delay through the communication procedure set out in the clause at reference 6.
 
 ## 17. Amendments of the Token Terms
 
 1. Issuer shall be entitled to amend or supplement the Token Terms without the prior consent of Investors, provided that such amendment or supplementation:
-    1. is necessary to correct manifest clerical or factual errors;
-    2. serves to clarify ambiguous or unclear provisions without changing the substantive rights or obligations of Investors; or
-    3. is necessary to adapt to technical, legal, or regulatory developments, provided such change does not materially prejudice Investor’s legal or financial position and is transparently communicated. Issuer shall provide reasons for such an amendment; or
-    4. is required by binding legal provisions, final judicial decisions, or binding administrative orders.
+   1. is necessary to correct manifest clerical or factual errors;
+   2. serves to clarify ambiguous or unclear provisions without changing the substantive rights or obligations of Investors; or
+   3. is necessary to adapt to technical, legal, or regulatory developments, provided such change does not materially prejudice Investor’s legal or financial position and is transparently communicated. Issuer shall provide reasons for such an amendment; or
+   4. is required by binding legal provisions, final judicial decisions, or binding administrative orders.
 2. If the amendment affects material provisions of the Token Terms, including rights, obligations, or the economic position of Investors, such amendment shall only take effect if Investor has expressly agreed to the amendment in advance. Issuer shall provide Investor with the proposed amendment in text form, explaining the reasons for the change. Issuer may ask Investor to provide consent electronically or in writing. If Investor does not consent, the existing Token Terms shall continue to apply. Issuer reserves the right to terminate the agreement with six (6) weeks’ notice, provided that continuation of the agreement would be unreasonable for Issuer. In cases where Investor refuses to consent to a material amendment pursuant to this section, Issuer may offer to redeem the affected Royalty Tokens at their fair market value in USDT, provided the redemption terms are transparent, objectively verifiable and not disadvantageous to Investors. Redemption shall be made to Investor’s last known wallet address.
 3. For the avoidance of doubt, the version of the Token Terms applicable to a specific Royalty Token Release shall be the version in force at the time of that Royalty Token Release.
 
@@ -314,6 +317,7 @@ means the pro-rata payments equal to the Total Distribution divided by the Royal
 ## 8. Event Of Default
 
 means any of the conditions or events described with reference to clause reference 7, which shall be deemed to constitute an Event Of Default if and for so long as they shall have occurred and be continuing:
+
 1. Issuer fails to pay any amount in respect to the Royalty Tokens when due and payable in a commercial reasonable timeframe, including as a result of Issuer having not received the corresponding Royalty Payments from Royalty Provider; or
 2. an Insolvency Event in relation to Issuer.
 
@@ -328,6 +332,7 @@ means the framework agreement between Royalty Provider and Issuer governing the 
 ## 11. Government Licence
 
 means the government licence granted to an entity to extract oil from the Oil Well, which regulates the:
+
 1. Wellbore; and
 2. the associated equipment, casing, and surface facilities.
 
@@ -342,9 +347,10 @@ means the aggregate gross revenue received by arising by or on behalf of Royalty
 ## 14. Insolvency Event
 
 means the occurrence of any of the following events in relation to any entity relevant to the performance of obligations under these Terms:
-1. is unable or is expected to be unable to pay its debts as they fall due (*Zahlungsunfähigkeit* or *drohende Zahlungsunfähigkeit*) within the meaning of Section 17 para. 2 or 18 para. 2 of the German Insolvency Code (*Insolvenzordnung*), or admits its inability to pay its debts as they fall due or insofar as it does not have its seat in the Federal Republic of Germany, is insolvent, admits its inability to pay its debts as they fall due or it generally discontinues payment to its debtors;
-2. is over-indebted (*überschuldet*) within the meaning of Section 19 of the German Insolvency Code (Insolvenzordnung) or insofar as it does not have its seat in the Federal Republic of Germany, its liabilities (taking into account conditional and future liabilities) exceed its assets;
-3. for any of the reasons set out in Sections 17 to 19 of the German Insolvency Code (*Insolvenzordnung*), files for insolvency (*Antrag auf Eröffnung eines Insolvenzverfahrens*) (also in cases of self-management of administration (Eigenverwaltung) against its assets) or its board members (*Vorstände*) or directors (*Geschäftsführer*) are required by law to file for insolvency, or a creditor files for the opening of insolvency proceedings (other than a petition or application which is vexatious or frivolous and which is discharged, stayed or dismissed within fourteen (14) Business Days of application); or
+
+1. is unable or is expected to be unable to pay its debts as they fall due (_Zahlungsunfähigkeit_ or _drohende Zahlungsunfähigkeit_) within the meaning of Section 17 para. 2 or 18 para. 2 of the German Insolvency Code (_Insolvenzordnung_), or admits its inability to pay its debts as they fall due or insofar as it does not have its seat in the Federal Republic of Germany, is insolvent, admits its inability to pay its debts as they fall due or it generally discontinues payment to its debtors;
+2. is over-indebted (_überschuldet_) within the meaning of Section 19 of the German Insolvency Code (Insolvenzordnung) or insofar as it does not have its seat in the Federal Republic of Germany, its liabilities (taking into account conditional and future liabilities) exceed its assets;
+3. for any of the reasons set out in Sections 17 to 19 of the German Insolvency Code (_Insolvenzordnung_), files for insolvency (_Antrag auf Eröffnung eines Insolvenzverfahrens_) (also in cases of self-management of administration (Eigenverwaltung) against its assets) or its board members (_Vorstände_) or directors (_Geschäftsführer_) are required by law to file for insolvency, or a creditor files for the opening of insolvency proceedings (other than a petition or application which is vexatious or frivolous and which is discharged, stayed or dismissed within fourteen (14) Business Days of application); or
 4. agrees to or declares a moratorium, or enters into any composition, compromise, arrangement, settlement or standstill agreement with any of its creditors in anticipation of financial difficulties.
 
 ## 15. Interface
@@ -394,6 +400,7 @@ means the portion of a Royalty Payment that is not subject to a Royalty Token Re
 ## 26. Permanent Payment Default
 
 means a situation in which
+
 1. no material recovery has been made within eighteen (18) months following the initial enforcement attempt despite reasonable efforts; or
 2. an Insolvency Event relating to Royalty Originator has occurred; or
 3. a court has issued a final and binding decision confirming that recovery of the due Royalty amounts is not possible.
@@ -465,6 +472,7 @@ means the agent acting as representative of Investors who, in its own name but o
 ## 43. Security Event
 
 means any security-related incident that compromises or threatens the technical functionality, legal integrity or economic model of the Royalty Token or associated infrastructure. A Security Event includes, but is not limited to:
+
 1. exploitation of bugs, vulnerabilities, or unintended functionality in the Royalty Token smart contract or any connected contracts such as treasury, snapshot, or distribution mechanisms;
 2. unauthorized deployment of or interaction with malicious smart contracts targeting the Royalty Token or related smart contract components (e.g., snapshot, airdrop or vault mechanisms);
 3. economic exploits such as flash loan attacks, re-entrancy attacks, or arbitrage-driven manipulations in the context of token allocation or trading functionality;
@@ -481,6 +489,7 @@ means the digital construct and permissions, implemented by smart contracts, man
 ## 45. Snapshot, Snapshots
 
 means a data snapshot of the relevant blockchain to determine the state of the blockchain in terms of:
+
 1. Royalty Token holdings; and
 2. for Variable Royalty Tokens, the supply,
 
@@ -533,7 +542,7 @@ means the borehole designated in the applicable Project Agreement as the source 
 1. Issuer;
 2. ATG AZIMUT TREUHANDGESELLSCHAFT MBH ("**Security Agent**"); and
 3. Investors.
- 
+
 ### 2. Definitions
 
 Terms defined elsewhere in these Token Terms shall have the meanings assigned to them where they have been defined. The following terms shall have the meanings set out below, and in the event of any inconsistency, the following definitions shall prevail:
@@ -553,12 +562,12 @@ Terms defined elsewhere in these Token Terms shall have the meanings assigned to
 13. **"Token Terms"** the terms specifically related to the Royalty Tokens which shall complete the general terms and conditions that are applicable to all tokens issued by Issuer.
 14. **"Total Distributions"** has the meaning as specified in the Token Terms.
 
- ### The Security Agent
+### The Security Agent
 
 1. Issuer and each Investor do hereby appoint pursuant to the terms and conditions of this Agreement the Security Agent with the authority to take the actions of the Security Agent under this Agreement. The Security Agent hereby accepts its obligations under this Agreement upon the terms and conditions hereof.
 2. The Security Agent may execute any of the trusts or powers hereof and perform any duty hereunder either directly or by or through agents. The Security Agent shall be entitled to advice of counsel concerning all matters pertaining to such trusts, powers and duties.
 3. Issuer shall provide the Security Agent and Investors with access to the information showing the current status of the Collateral.
- 
+
 ### 3. Security Assignment
 
 Issuer hereby transfers any Collateral by way of security to the Security Agent and assigns any of its claims and enforcement rights against Royalty Provider for payment of Total Distributions to the Security Agent as security in order to secure the Secured Claims.
@@ -589,10 +598,10 @@ Notwithstanding anything to the contrary herein, no recourse (whether by institu
 ### 7. Replacement of Security Agent
 
 1. The Security Agent may resign at any time by notifying Issuer in writing not less than ninety (90) days prior to the effective date of such resignation. Issuer shall remove the Security Agent if:
-    1. the Security Agent fails to comply with its obligations;
-    2. the Security Agent is adjudged as bankrupt or insolvent;
-    3. a receiver or other public officer takes charge of the Security Agent or its property; or
-    4. the Security Agent otherwise becomes incapable of acting.
+   1. the Security Agent fails to comply with its obligations;
+   2. the Security Agent is adjudged as bankrupt or insolvent;
+   3. a receiver or other public officer takes charge of the Security Agent or its property; or
+   4. the Security Agent otherwise becomes incapable of acting.
 2. If the Security Agent resigns or is removed for any reason, Issuer shall promptly appoint a successor Security Agent.
 3. Any successor Security Agent shall deliver a written acceptance of its appointment to the retiring Security Agent and to Issuer. Thereupon, the resignation or removal of the retiring Security Agent shall become effective, and the successor Security Agent shall have all the rights, powers and duties of the Security Agent under this Agreement. The retiring Security Agent shall promptly transfer all property held by it as Security Agent to the successor Security Agent.
 
@@ -617,9 +626,9 @@ Terms defined elsewhere in these Token Terms shall have the meanings assigned to
 1. **Agreement** means the agreement known as the _Framework Revenue Purchase Agreement_ between the parties, originally dated 9 September 2025, as amended from time to time
 2. **Base Prospectus** means the base prospectus to be prepared by Issuer and Royalty Provider as co-issuers in accordance with Regulation (EU) 2017/1129 (the Prospectus Regulation) as may be approved, amended or supplemented from time to time.
 3. **Licensed IP** means:
-    1. the code licensed to Issuer in connection with its issuance of Royalty Tokens;
-    2. the 'Albion Labs' brand name; and
-    3. logos, trademarks, trade names and associated intellectual property rights concerning the 'Albion Labs' brand name or the URL as notified to Royalty Provider in writing from time to time.
+   1. the code licensed to Issuer in connection with its issuance of Royalty Tokens;
+   2. the 'Albion Labs' brand name; and
+   3. logos, trademarks, trade names and associated intellectual property rights concerning the 'Albion Labs' brand name or the URL as notified to Royalty Provider in writing from time to time.
 4. **Release Token Terms** means the specific Token Terms document accompanying an offer to enter into a Revenue Purchase Agreement by Royalty Provider, which will be substantially in the form of the Token Terms.
 5. **Revenue Purchase Agreement** means the agreements arising from the activity of the parties to the Agreement under which Issuer may acquire royalty interests from Royalty Provider.
 6. **URL** means http://www.albionlabs.org.
@@ -630,20 +639,20 @@ Terms defined elsewhere in these Token Terms shall have the meanings assigned to
 
 1. Royalty Provider is required to issue to Issuer a binding offer for the conclusion of Revenue Purchase Agreement(s).
 2. Each offer is to include the parameters for the agreement, including:
-    1. the relevant purchase price;
-    2. the purchase payment period;
-    3. the revenue payment start date;
-    4. the revenue payment percentage; and
-    5. any special conditions (which override the terms of the Agreement to the extent of any inconsistency).
+   1. the relevant purchase price;
+   2. the purchase payment period;
+   3. the revenue payment start date;
+   4. the revenue payment percentage; and
+   5. any special conditions (which override the terms of the Agreement to the extent of any inconsistency).
 3. The offer must also set out the Release Token Terms and the following particulars which are to be derived from the Token Terms:
-    1. the royalty payment percentage;
-    2. royalty token price;
-    3. payment token exclusive;
-    4. supply type;
-    5. supply limit; and
-    6. management fees.
-    7. The offer must also include other relevant information including the pending distributions.
-    8. Royalty Provider shall be bound by each offer for a period of five calendar days from the date of receipt by Issuer, unless a different binding period is expressly stated in the offer.
+   1. the royalty payment percentage;
+   2. royalty token price;
+   3. payment token exclusive;
+   4. supply type;
+   5. supply limit; and
+   6. management fees.
+   7. The offer must also include other relevant information including the pending distributions.
+   8. Royalty Provider shall be bound by each offer for a period of five calendar days from the date of receipt by Issuer, unless a different binding period is expressly stated in the offer.
 
 **B. Acceptance**
 
@@ -656,7 +665,7 @@ Terms defined elsewhere in these Token Terms shall have the meanings assigned to
 1. The purchase price under each Revenue Purchase Agreement is determined based on the revenue payment percentage applied to the royalty payments that Royalty Provider receives from Royalty Originator.
 2. The purchase price is due from Issuer by no later than the 10th day of each calendar month during the payment period for the relevant Revenue Purchase Agreement. It is to be calculated on a pro-rata basis by reference to the number of months in the payment period.
 
-### 4. Purchase Price Suspension	
+### 4. Purchase Price Suspension
 
 Issuer’s obligation to pay the Purchase Price is suspended when Royalty Provider does not pay the revenue payments by the due date, until Royalty Provider resumes the revenue payments.
 
@@ -677,39 +686,43 @@ Royalty Provider shall promptly notify Issuer of any delay or likely delay in th
 ### 5. Co-Issuance
 
 The Parties will co-issue Royalty Tokens as co-issuers to Investors under a Base Prospectus on the following basis:
+
 1. Royalty Provider will be responsible for conducting marketing and promotion in connection with each Royalty Token Release.
 2. Issuer will use the royalty interests acquired under each Revenue Purchase Agreement for the purposes of each Royalty Token Release.
 3. Issuer may receive the assistance of third-party service providers to act as co-issuer for a Royalty Token Release.
 4. Issuer's sole obligations (“**Issuer Obligations**”) in connection with each Royalty Token Release are limited to:
-    1. making payments to Investors in accordance with the Token Terms, provided it has received the corresponding payments from Royalty Provider; and
-    2. verifying the accuracy and completeness of all information concerning Issuer that is included in the Token Terms, the Base Prospectus or any prospectus concerning a Royalty Token Release, or any other materials made available to Investors concerning a Royalty Token Release.
+   1. making payments to Investors in accordance with the Token Terms, provided it has received the corresponding payments from Royalty Provider; and
+   2. verifying the accuracy and completeness of all information concerning Issuer that is included in the Token Terms, the Base Prospectus or any prospectus concerning a Royalty Token Release, or any other materials made available to Investors concerning a Royalty Token Release.
 
 ### 6. Licensed IP and URL Rights
 
 **A. License of Licensed IP**
 
 Issuer grants to Royalty Provider a non-exclusive, unlimited, global, sub-licensable, transferable, royalty-free license to use the Licensed IP for the purpose of:
+
 1. conducting marketing and promotion in connection with each Royalty Token Release; and
 2. taking such other steps as an issuer for a Royalty Token Release as it deems, acting reasonably, are necessary or desirable.
 
 **B. Access to the URL**
 
 Issuer grants to Royalty Provider the right to use, operate and maintain the URL for the purpose of:
+
 1. conducting marketing and promotion in connection with each Royalty Token Release; and
 2. taking such other steps as an issuer for a Royalty Token Release as it deems, acting reasonably, are necessary or desirable.
 
 ### 7. Liability
 
 1. Royalty Provider and Issuer agree that:
-    1. Royalty Provider will be liable for all third-party claims (including claims made by Investors or a security agent on their behalf) relating to Royalty Token Releases, and will indemnify Issuer from and against any such third-party claims;
-    2. Issuer will indemnify Royalty Provider from and against any third-party claims (including claims made by Investors or a security agent on their behalf), to the extent those claims relate to a breach by Issuer of any of Issuer Obligations;
-    3. except in cases of a breach by Issuer of any of Issuer Obligations, the liability of Issuer shall be excluded; and
-    4. the liability of Royalty Provider for any Issuer Obligations shall be excluded.
+   1. Royalty Provider will be liable for all third-party claims (including claims made by Investors or a security agent on their behalf) relating to Royalty Token Releases, and will indemnify Issuer from and against any such third-party claims;
+   2. Issuer will indemnify Royalty Provider from and against any third-party claims (including claims made by Investors or a security agent on their behalf), to the extent those claims relate to a breach by Issuer of any of Issuer Obligations;
+   3. except in cases of a breach by Issuer of any of Issuer Obligations, the liability of Issuer shall be excluded; and
+   4. the liability of Royalty Provider for any Issuer Obligations shall be excluded.
 2. Liability for culpable injury to life, body or health as well as liability under the German Product Liability Act shall remain unaffected.
 
 ### 8. Payment to Issuer
 
 Royalty Provider agrees to:
+
 1. reimburse Issuer for third-party costs Issuer incurs with permission in connection with the performance of its role of issuer under any Royalty Token Release, including costs charged by security agents or third-party service providers; and
 2. pay to Issuer USD 2000 (or a stablecoin equivalent) per calendar month.
 
@@ -725,7 +738,7 @@ The governing law of the Agreement is the law of Germany and the courts of Berli
 # Schedule 3 - Revenue Swap Agreement Summary
 
 ### 1. Parties
-  
+
 1. Royalty Provider; and
 2. Royalty Originator.
 
@@ -755,11 +768,11 @@ The term of the Royalty Interest is 1 May 2025 until termination as the result o
 **C. Payment Reporting**
 
 1. Within 30 calendar days of the end of each month, Royalty Originator will provide a statement to Royalty Provider detailing:
-    1. the Gross Revenue for that month taking into account any corrections to errors made in previous statements; and
-    2. the payment due to Royalty Provider for that month.
+   1. the Gross Revenue for that month taking into account any corrections to errors made in previous statements; and
+   2. the payment due to Royalty Provider for that month.
 2. In the event Royalty Originator fails to provide this statement to Royalty Provider, the payment due to Royalty Provider will be deemed to be the higher of:
-    1. the highest previous monthly payment; or
-    2. the market value of the petroleum forecast to be produced for that month.
+   1. the highest previous monthly payment; or
+   2. the market value of the petroleum forecast to be produced for that month.
 
 **D. Payment Schedule**
 
@@ -805,13 +818,14 @@ Royalty Originator is required to ensure that the Royalty Interest is paid to Ro
 **M. Termination**
 
 The Royalty Interest will terminate on the earlier of:
+
 1. 31 December 2029; or
 2. on the occurrence of any of the following events:
-    1. the termination or relinquishment of the Licence as required by law or the North Sea Transition Authority;
-    2. a capital expenditure of more than $200,000 in the Oil Well after 31 December 2027;
-    3. the Side Tracking of the Oil Well;
-    4. Royalty Provider terminating the Agreement following the occurrence of certain insolvency-related events; or
-    5. the parties agreeing to terminate the Agreement.
+   1. the termination or relinquishment of the Licence as required by law or the North Sea Transition Authority;
+   2. a capital expenditure of more than $200,000 in the Oil Well after 31 December 2027;
+   3. the Side Tracking of the Oil Well;
+   4. Royalty Provider terminating the Agreement following the occurrence of certain insolvency-related events; or
+   5. the parties agreeing to terminate the Agreement.
 
 **N. Sale or Change of Control**
 
@@ -820,4 +834,3 @@ If Royalty Originator assigns or otherwise transfers all or any part of any inte
 **O. Governing Law**
 
 The governing law of the Agreement is England and the courts of England have exclusive jurisdiction to settle any disputes arising from the Agreement.
-

--- a/static/token_terms/0xf836a500910453A397084ADe41321ee20a5AAde1.md
+++ b/static/token_terms/0xf836a500910453A397084ADe41321ee20a5AAde1.md
@@ -1,5 +1,4 @@
-Albion Token Terms (Community Preview 1)
-===========
+# Albion Token Terms (Community Preview 1)
 
 _September 2025_
 
@@ -88,42 +87,42 @@ Finally, you represent that you will fully comply with all applicable laws and r
 ## 1. Interpretation Principles
 
 1. In these Token Terms, unless the context otherwise requires:
-    1. references to these Token Terms shall include any schedules to it and references to clauses, subclauses and any schedules are to clauses of, sub-clauses of, and any schedules to these Token Terms;
-    2. the singular includes the plural and vice versa;
-    3. “person” denotes any person, partnership, corporation or other association of whatever nature; and
-    4. any references to any directive, statute, statutory instrument, laws or regulations shall be references to such directive, statute, statutory instrument, laws or regulations as from time to time amended, re-enacted or replaced and to any codification, consolidation, re-enactment or substitution thereof as from time to time in force and any reference to a regulator or public authority and rules made by it shall include its successor and rules made by the successor which replace those rules.
+   1. references to these Token Terms shall include any schedules to it and references to clauses, subclauses and any schedules are to clauses of, sub-clauses of, and any schedules to these Token Terms;
+   2. the singular includes the plural and vice versa;
+   3. “person” denotes any person, partnership, corporation or other association of whatever nature; and
+   4. any references to any directive, statute, statutory instrument, laws or regulations shall be references to such directive, statute, statutory instrument, laws or regulations as from time to time amended, re-enacted or replaced and to any codification, consolidation, re-enactment or substitution thereof as from time to time in force and any reference to a regulator or public authority and rules made by it shall include its successor and rules made by the successor which replace those rules.
 2. Headings are for convenience only and have no bearing on the interpretation of these Token Terms.
 3. Any phrase introduced by the term “include”, “includes”, “including”, “for example”, “in particular” or any similar expression will be construed as illustrative and will not limit the sense of the words preceding that term.
 4. References to “dealing in” or “deal in” are references to any participation in crypto assets including buying, acquiring, accepting, holding, selling, staking, disposing of or otherwise making use of crypto assets.
 
 ## 2. KYC AML and Greenlisting [REFERENCE 1]
 
-1. In order to purchase and/or redeem Royalty Tokens, a successful onboarding of the Investor and completion of the KYC AML Requirements by the Investor, including the provision of all required data and confirmation of eligibility, is required. 
+1. In order to purchase and/or redeem Royalty Tokens, a successful onboarding of the Investor and completion of the KYC AML Requirements by the Investor, including the provision of all required data and confirmation of eligibility, is required.
 2. Eligible to purchase and/or redeem Royalty Tokens are all natural and legal persons as well as partnerships with a legal personality if they fulfil the following requirements:
-    1. the Investor is neither a citizen of nor does possess a permanent residence or working permit for the United States of America (USA), Canada, China, Australia or Iran and has no residence or registered office within the territory of one of these states;
-    2. the Investor is not a corporation or other entity organized under federal or any state law of the USA or under the comparable law of Canada, China, Australia or Iran of which the income is subject to the law of one of the aforementioned jurisdictions; and
-    3. neither the Investor nor the Investor’s Wallet is listed on neither one of the European Union’s nor on one of the United States of America’s respective sanction lists.
+   1. the Investor is neither a citizen of nor does possess a permanent residence or working permit for the United States of America (USA), Canada, China, Australia or Iran and has no residence or registered office within the territory of one of these states;
+   2. the Investor is not a corporation or other entity organized under federal or any state law of the USA or under the comparable law of Canada, China, Australia or Iran of which the income is subject to the law of one of the aforementioned jurisdictions; and
+   3. neither the Investor nor the Investor’s Wallet is listed on neither one of the European Union’s nor on one of the United States of America’s respective sanction lists.
 3. The following information is required for onboarding if the Investor is a natural person:
-    1. all names and surnames of the Investor;
-    2. the declared place of residence including the complete address;
-    3. the Investor’s date of birth;
-    4. the Investor’s place of birth;
-    5. the nationality of the Investor;
-    6. the number of an identity card or passport which has been issued by the competent authority to the Investor; and
-    7. an e-mail address of the Investor. 
-    8. Additional information may be required in enhanced due diligence processes.
+   1. all names and surnames of the Investor;
+   2. the declared place of residence including the complete address;
+   3. the Investor’s date of birth;
+   4. the Investor’s place of birth;
+   5. the nationality of the Investor;
+   6. the number of an identity card or passport which has been issued by the competent authority to the Investor; and
+   7. an e-mail address of the Investor.
+   8. Additional information may be required in enhanced due diligence processes.
 4. The following information is required for onboarding if the Investor is an entity or a partnership with a legal personality:
-    1. complete legal form of the Investor;
-    2. statutory, or where applicable, the place of business of the Investor as registered in a public registry including the complete address;
-    3. (if existing) the Investors registry number from the commercial registry or a comparable public registry;
-    4. name of the statutory authorized representative or representatives of the Investor;
-    5. an e-mail address of the Investor. 
-    6. Additional information may be required in enhanced due diligence processes.
+   1. complete legal form of the Investor;
+   2. statutory, or where applicable, the place of business of the Investor as registered in a public registry including the complete address;
+   3. (if existing) the Investors registry number from the commercial registry or a comparable public registry;
+   4. name of the statutory authorized representative or representatives of the Investor;
+   5. an e-mail address of the Investor.
+   6. Additional information may be required in enhanced due diligence processes.
 5. As part of the onboarding process, the Investor is asked to name a Blockchain Wallet address to which the Royalty Tokens can be transferred after successful completion of the onboarding process. Investors may be asked to provide confirmation of ownership or control of the Wallet. A Wallet screen may be conducted as part of the onboarding process.
 6. For the onboarding to be successful it is required that the information provided by the Investor is:
-    1. complete; and
-    2. that there is no indication that the Investor provided incorrect data.
-7. The Issuer is entitled but not obligated to audit the data provided during the onboarding process by a qualified third party. 
+   1. complete; and
+   2. that there is no indication that the Investor provided incorrect data.
+7. The Issuer is entitled but not obligated to audit the data provided during the onboarding process by a qualified third party.
 8. The Issuer notifies the Investor if the onboarding and the completion of the KYC AML Requirements was successful. The respective Investor is then considered as Greenlisted.
 9. The Investor is obligated to notify the Issuer immediately if any of the information provided has changed.
 
@@ -134,8 +133,8 @@ Finally, you represent that you will fully comply with all applicable laws and r
 3. Royalty Tokens may be subscribed for as part of specific Royalty Token Releases by submitting a purchase application to the Issuer via the designated Interface. The Investor must specify the intended subscription amount, provide a compatible Blockchain Wallet address and pay the applicable Royalty Token Price before the Royalty Tokens are transferred.
 4. The economic parameters applicable to each Royalty Token Release, including the underlying asset, Royalty Interest, Royalty Payment Percentage, Royalty Token Price, Supply Type, Supply Limit, and, if applicable, Management Fees, are set out in the Particulars table for each Release. These Particulars are made available to Investors via the system Interface.
 5. Each Royalty Token Release is a type of Royalty Token, either:
-    1. a Fixed Royalty Token; or
-    2. a Variable Royalty Token.
+   1. a Fixed Royalty Token; or
+   2. a Variable Royalty Token.
 6. Royalty Tokens are transferred to the Investor after full payment of the Royalty Token Price to the Wallet address provided by the Investor. Payment must be made in the currency specified in the applicable Particulars for that Royalty Token Release.
 7. Issuance of Royalty Tokens is permitted only for Investors who have successfully completed the onboarding process and are considered Greenlisted by the Issuer.
 
@@ -145,14 +144,14 @@ Finally, you represent that you will fully comply with all applicable laws and r
 2. Investors are entitled to receive pro-rata Distributions from the Issuer, which reflect Revenue Payments received by the Issuer under the Revenue Purchase Agreement. These Revenue Payments result from Royalty Payments made by the Royalty Supplier to the Royalty Provider under the Revenue Swap Agreement. These Total Distributions are determined based on the Royalty Interest acquired by the Issuer under the applicable Revenue Purchase Agreement and the Royalty Payment Percentage specified for the relevant Royalty Token Release. Any such Distributions shall only become due and payable by the Issuer to Investors upon actual receipt of the corresponding Total Distributions as Revenue Payments from the Royalty Provider.
 3. To the extent that interest is payable by the Royalty Supplier in connection with delayed or outstanding Royalty Payments under the Revenue Swap Agreement and such amounts are acquired by the Issuer as Revenue Payments under the Revenue Purchase Agreement, such interest shall be treated as part of the Total Distributions and distributed by the Issuer to Investors accordingly.
 4. Distributions to Investors for both Supply Types (Fixed or Variable) are calculated based on the following steps.
-    1. Royalty Interest including increases or reductions (minus fees of Royalty Provider), split between Royalty Token Releases according to the Royalty Payment Percentages, to get the Total Distribution.
-    2. Total Distribution divided by the quantity of Royalty Tokens minted for the applicable Royalty Token Release to get the payment per Royalty Token held by an Investor during a month, which is determined by reference to the Snapshot process described by the clause at Reference 2.
+   1. Royalty Interest including increases or reductions (minus fees of Royalty Provider), split between Royalty Token Releases according to the Royalty Payment Percentages, to get the Total Distribution.
+   2. Total Distribution divided by the quantity of Royalty Tokens minted for the applicable Royalty Token Release to get the payment per Royalty Token held by an Investor during a month, which is determined by reference to the Snapshot process described by the clause at Reference 2.
 5. For Fixed Royalty Tokens, Distributions are calculated as an equal share of the Total Distribution allocated to the corresponding Royalty Token Release based on the fixed number of Tokens defined as the Supply Limit in the Particulars. Each Royalty Token represents a fixed portion of the Total Distribution for that Royalty Token Release.
-6. For Variable Royalty Tokens, Distributions are calculated based on the number of Royalty Tokens in circulation at the time of the Snapshots and the number of Royalty Tokens held in the Investor’s Wallet. Variable Royalty Tokens are minted progressively upon acquisition by Investors from the Issuer until the Supply Limit specified in the Particulars is reached. 
+6. For Variable Royalty Tokens, Distributions are calculated based on the number of Royalty Tokens in circulation at the time of the Snapshots and the number of Royalty Tokens held in the Investor’s Wallet. Variable Royalty Tokens are minted progressively upon acquisition by Investors from the Issuer until the Supply Limit specified in the Particulars is reached.
 7. Where a portion of the Revenue Payment is not allocated to an active Royalty Token Release, it will be retained as Pending Distributions and distributed to Investors on a pro-rata basis in accordance with the Royalty Payment Percentage over the first twelve (12) Distribution cycles of the relevant Royalty Token Release.
 8. Distributions are determined based on two blockchain Snapshots taken per calendar day by the Issuer, without prior notice. These Snapshots record for each Royalty Token Release:
-    1. Wallet Balance; and 
-    2. Release Supply. 
+   1. Wallet Balance; and
+   2. Release Supply.
 9. For each Distribution cycle, to calculate the percentage of the Total Distribution for payment to a Wallet, the Issuer shall determine the average of the Wallet Balance and Release Supply between the Snapshots and use the following formula: average Wallet Balance divided by average Release Supply multiplied by 100. [Reference 2]
 10. Investors must hold Royalty Tokens at the time of at least one of the Snapshots in order to be eligible for a Distribution in the relevant month. The Distribution amount is then calculated as described in the clause at Reference 2. No Distributions are made to a Wallet if the Token is not held by a Wallet in either Snapshot. [Reference 3]
 11. In the event that Royalty Payments under the Revenue Swap Agreement are temporarily suspended and subsequently recommence, Distributions to Investors shall be calculated based on the Snapshots taken during the period of suspension. This applies only if such Snapshots were validly recorded by the Issuer in accordance with the clause at Reference 3 and ensures that Distribution rights accrued during the suspension are preserved upon recommencement of Revenue Payments.
@@ -166,50 +165,50 @@ Finally, you represent that you will fully comply with all applicable laws and r
 ## 5. Disruption of Royalty Payments
 
 1. The Investor’s entitlement to future Distributions under a Royalty Token Release may be temporarily suspended, delayed, proportionally reduced or permanently ceased, in whole or in part, if circumstances beyond the control of the Issuer materially affect the accrual, calculation or legal enforceability of the underlying Royalty Payments from Royalty Supplier to Royalty Provider and / or Revenue Payments from Royalty Provider to Issuer, and / or Total Distributions from Royalty Provider to Issuer. Such circumstances include, but are not limited to:
-    1. operational disruptions or technical failure at the Oil Well, including breakdowns or production stoppages;
-    2. economic or technical depletion of the Wellbore, including side-tracking, cessation of production or additional capital expenditure by the Royalty Supplier;
-    3. suspension, termination, expiry or non-renewal of the Project Agreement, the Offtake Agreement, the Revenue Swap Agreement or the Government Licence;
-    4. failure by the Royalty Supplier to make due Royalty Payments to the Royalty Provider, including partial or delayed payments;
-    5. breach of contract, non-performance or an Insolvency Event affecting the Royalty Supplier, Royalty Provider or any other material contractual party;
-    6. failure or disruption involving third-party service providers essential to Royalty operations, including subcontractors, payment processors or banking;
-    7. governmental action or regulatory intervention (e.g., licence revocation or changes in tax, civil or regulatory frameworks) that make continued performance legally or economically unfeasible;
-    8. drastic market developments (e.g., oil price volatility or adverse currency fluctuations) materially affecting Royalty revenue;
-    9. transfer or assumption of the Royalty Supplier’s interest under the Project Agreement that materially impacts the performance of the Royalty;
-    10. administrative, management or tax costs exceeding the expected value of Royalty Payments;
-    11. in the event of Force Majeure;
-    12. security-related events including hacking, fraud, or systemic blockchain vulnerabilities leading to necessary freezing of the Royalty Token functionality or vault access.
+   1. operational disruptions or technical failure at the Oil Well, including breakdowns or production stoppages;
+   2. economic or technical depletion of the Wellbore, including side-tracking, cessation of production or additional capital expenditure by the Royalty Supplier;
+   3. suspension, termination, expiry or non-renewal of the Project Agreement, the Offtake Agreement, the Revenue Swap Agreement or the Government Licence;
+   4. failure by the Royalty Supplier to make due Royalty Payments to the Royalty Provider, including partial or delayed payments;
+   5. breach of contract, non-performance or an Insolvency Event affecting the Royalty Supplier, Royalty Provider or any other material contractual party;
+   6. failure or disruption involving third-party service providers essential to Royalty operations, including subcontractors, payment processors or banking;
+   7. governmental action or regulatory intervention (e.g., licence revocation or changes in tax, civil or regulatory frameworks) that make continued performance legally or economically unfeasible;
+   8. drastic market developments (e.g., oil price volatility or adverse currency fluctuations) materially affecting Royalty revenue;
+   9. transfer or assumption of the Royalty Supplier’s interest under the Project Agreement that materially impacts the performance of the Royalty;
+   10. administrative, management or tax costs exceeding the expected value of Royalty Payments;
+   11. in the event of Force Majeure;
+   12. security-related events including hacking, fraud, or systemic blockchain vulnerabilities leading to necessary freezing of the Royalty Token functionality or vault access.
 2. In such cases, the Issuer will inform Investors via the system Interface without undue delay, where feasible, and may apply one or more of the following remedial measures:
-    1. temporary suspension of Distributions with the possibility of subsequent catch-up; such catch-up payments shall be made exclusively to those Investors who, according to the Snapshot data, held the relevant Royalty Tokens during the period in which the Revenue Payment is not received by the Issuer, in proportion to their Wallet Balance recorded at the relevant Snapshot dates; where the Total Distributions actually received by the Issuer for the relevant period is lower than the Total Distribution originally due, the catch-up payments will make up the difference relative to the originally due Total Distribution;
-    2. permanent cessation of Distributions, if the underlying Royalty entitlement has definitively ceased or cannot reasonably be expected to resume due to legal, operational or economic reasons;
-    3. pro-rata allocation of any alternative settlement or negotiated outcome between the Royalty Provider and Royalty Supplier to Investors, based on the Wallet Balance recorded for each Investor at the relevant Snapshot dates during the period in which the underlying Revenue Payment is not received by the Issuer; if the total amount actually received by the Royalty Provider under such settlement or negotiated outcome is lower than the aggregate Total Distribution originally due for that period, the amount allocable to each Investor shall be reduced in the same proportion as the total settlement amount bears to the aggregate originally due Total Distribution;
-    4. application of Pending Distributions, if available, to offset temporary shortfalls in Distributions;
-    5. resumption of Distributions, if applicable, based on the Snapshot balances recorded during the suspension period, unless otherwise determined in accordance with the Token Terms.
+   1. temporary suspension of Distributions with the possibility of subsequent catch-up; such catch-up payments shall be made exclusively to those Investors who, according to the Snapshot data, held the relevant Royalty Tokens during the period in which the Revenue Payment is not received by the Issuer, in proportion to their Wallet Balance recorded at the relevant Snapshot dates; where the Total Distributions actually received by the Issuer for the relevant period is lower than the Total Distribution originally due, the catch-up payments will make up the difference relative to the originally due Total Distribution;
+   2. permanent cessation of Distributions, if the underlying Royalty entitlement has definitively ceased or cannot reasonably be expected to resume due to legal, operational or economic reasons;
+   3. pro-rata allocation of any alternative settlement or negotiated outcome between the Royalty Provider and Royalty Supplier to Investors, based on the Wallet Balance recorded for each Investor at the relevant Snapshot dates during the period in which the underlying Revenue Payment is not received by the Issuer; if the total amount actually received by the Royalty Provider under such settlement or negotiated outcome is lower than the aggregate Total Distribution originally due for that period, the amount allocable to each Investor shall be reduced in the same proportion as the total settlement amount bears to the aggregate originally due Total Distribution;
+   4. application of Pending Distributions, if available, to offset temporary shortfalls in Distributions;
+   5. resumption of Distributions, if applicable, based on the Snapshot balances recorded during the suspension period, unless otherwise determined in accordance with the Token Terms.
 3. The Investor acknowledges that the Royalty and consequently any Royalty Payments and Distributions are strictly limited to the revenue generated from the original Wellbore as specified in the relevant Royalty Token Release. If the Royalty Supplier undertakes new capital expenditures (e.g. sidetracking, drilling of new wells or modifying the existing Wellbore), the Royalty is very unlikely to extend to the resulting new production. In such cases, Royalty Payments under the terms of the existing Revenue Swap Agreement may cease without any entitlement to participate in revenues from future production.
 
 ## 6. Termination for Good Cause
 
 1. Ordinary termination rights are excluded.
 2. Either Party may terminate the contractual relationship underlying these Token Terms with immediate effect for good cause (extraordinary termination), provided that the terminating Party cannot reasonably be expected to continue the contractual relationship under the given circumstances. A good cause shall be deemed to exist in particular, but not exclusively, in the following cases:
-    1. an Insolvency Event relating to the Issuer, Royalty Supplier or Royalty Provider occurs;
-    2. the underlying Revenue Swap Agreement or any other fundamental contractual arrangement essential to the operation and entitlement of the Royalty, such as the Government Licence or the Offtake Agreement, is terminated, expires or becomes legally or factually unenforceable on a permanent basis;
-    3. a change in applicable law, tax regulation or regulatory interpretation occurs that makes it legally or economically impossible or unreasonable to continue the Royalty structure or to make further Distributions;
-    4. one of the Parties commits a material breach of its contractual obligations and fails to remedy such breach within a reasonable grace period, if applicable, and the non-breaching Party cannot reasonably be expected to continue the contractual relationship.
+   1. an Insolvency Event relating to the Issuer, Royalty Supplier or Royalty Provider occurs;
+   2. the underlying Revenue Swap Agreement or any other fundamental contractual arrangement essential to the operation and entitlement of the Royalty, such as the Government Licence or the Offtake Agreement, is terminated, expires or becomes legally or factually unenforceable on a permanent basis;
+   3. a change in applicable law, tax regulation or regulatory interpretation occurs that makes it legally or economically impossible or unreasonable to continue the Royalty structure or to make further Distributions;
+   4. one of the Parties commits a material breach of its contractual obligations and fails to remedy such breach within a reasonable grace period, if applicable, and the non-breaching Party cannot reasonably be expected to continue the contractual relationship.
 3. The extraordinary termination must be declared in text form (e.g. via the Interface or email). Termination shall not affect any claims that have already arisen prior to the effective date of termination, particularly any pending or accrued Distributions.
 
 ## 7. Issuer Rights [REFERENCE 4]
 
-1. In the event of a Security Event the Issuer shall have the right, at its sole and reasonable discretion, to take any of the following remedial measures to protect the integrity of the Royalty Token system, subject to applicable law and with due regard to the interests of the Investors: 
-    1. The Issuer may suspend all transactions involving the affected SFT Bucket, including minting, burning and transfers of Tokens, until the risk has been resolved or mitigated. As part of this measure, the Issuer may activate a smart contract-based freeze function to technically enforce the suspension of all Royalty Token activity. During the freeze, Investors will not be able to transfer, acquire or otherwise dispose of their Royalty Tokens. The freeze shall be lifted once the relevant risk has been assessed and mitigated. 
-    2. The Issuer may deploy a new SFT Bucket to replace the affected smart contract infrastructure. In this case, the Issuer may distribute new replacement Royalty Tokens via airdrop to Investors recorded in a Snapshot prior to the Security Event or establish a swap mechanism allowing Investors to voluntarily exchange old Royalty Tokens for new ones.
-    3. To preserve the legal and economic integrity of the Royalty Token system and to avoid unjust enrichment of malicious actors, the Issuer shall have the sole and absolute discretion to exclude any Wallets that are, directly or indirectly connected with the Security Event from participating in any Royalty Token airdrop or other remedial measure under this section at Reference 4.
-    4. This section at Reference 4 shall not limit the Issuer's liability for intent, gross negligence or damages resulting from injury to life, body or health. The discretionary powers granted to the Issuer herein shall be exercised in good faith and in a manner that is reasonable, transparent and proportionate to the nature of the Security Event.
+1. In the event of a Security Event the Issuer shall have the right, at its sole and reasonable discretion, to take any of the following remedial measures to protect the integrity of the Royalty Token system, subject to applicable law and with due regard to the interests of the Investors:
+   1. The Issuer may suspend all transactions involving the affected SFT Bucket, including minting, burning and transfers of Tokens, until the risk has been resolved or mitigated. As part of this measure, the Issuer may activate a smart contract-based freeze function to technically enforce the suspension of all Royalty Token activity. During the freeze, Investors will not be able to transfer, acquire or otherwise dispose of their Royalty Tokens. The freeze shall be lifted once the relevant risk has been assessed and mitigated.
+   2. The Issuer may deploy a new SFT Bucket to replace the affected smart contract infrastructure. In this case, the Issuer may distribute new replacement Royalty Tokens via airdrop to Investors recorded in a Snapshot prior to the Security Event or establish a swap mechanism allowing Investors to voluntarily exchange old Royalty Tokens for new ones.
+   3. To preserve the legal and economic integrity of the Royalty Token system and to avoid unjust enrichment of malicious actors, the Issuer shall have the sole and absolute discretion to exclude any Wallets that are, directly or indirectly connected with the Security Event from participating in any Royalty Token airdrop or other remedial measure under this section at Reference 4.
+   4. This section at Reference 4 shall not limit the Issuer's liability for intent, gross negligence or damages resulting from injury to life, body or health. The discretionary powers granted to the Issuer herein shall be exercised in good faith and in a manner that is reasonable, transparent and proportionate to the nature of the Security Event.
 2. The Issuer is entitled to upgrade the functionality of the Royalty Token, in particular to improve security, efficiency or regulatory compliance. For this purpose, the Issuer may provide a 1:1 swap mechanism via a smart contract, allowing Investors to voluntarily exchange their existing Royalty Tokens for new Royalty Tokens with updated functionality. The existing rights associated with the Royalty Token shall remain unaffected until the swap is executed such that the terms of the new Royalty Tokens will come into effect between the Parties and the agreement represented by the old Royalty Token will be terminated immediately.
 3. The Issuer may, upon receipt of a binding and enforceable order issued by a competent legal authority with jurisdiction, confiscate Royalty Tokens held by an Investor if such measure is strictly required to comply with applicable laws or regulations (including but not limited to sanctions, anti-money laundering obligations, or court orders). In such case, the relevant Royalty Tokens may be transferred to a designated wallet specified by the authority or technically restricted (e.g., via freezing or blocking of transfers). The Issuer shall notify the affected Investor of the measure and the underlying legal basis without undue delay, unless prohibited by law. If such action is later found to have been erroneous or unlawful, the Investor shall be entitled to appropriate restitution or restoration of their Royalty Token holdings, where legally and technically feasible. Any confiscation without legal basis or compensation is expressly excluded. All other rights of the Investor under these Token Terms remain unaffected.
 4. The Issuer will disclose data received from the Royalty Supplier by way of the Royalty Provider regarding the Oil Well, once such data becomes publicly available, at all times in accordance with the rules applicable to the Parties connected with:
-    1. market transparency;
-    2. competitively sensitive information;
-    3. other rules connected with the disclosure of information relevant to publicly listed entities; and
-    4. the performance of the underlying assets from which the Royalty Payments are derived.
+   1. market transparency;
+   2. competitively sensitive information;
+   3. other rules connected with the disclosure of information relevant to publicly listed entities; and
+   4. the performance of the underlying assets from which the Royalty Payments are derived.
 
 ## 8. Qualified Subordination
 
@@ -223,12 +222,12 @@ Finally, you represent that you will fully comply with all applicable laws and r
 ## 9. Token Rights and Transfer
 
 1. The Royalty Token does not grant the Investor any ownership, co-ownership or property rights in the underlying Royalty, the Revenue Swap Agreement or the associated energy asset. In particular:
-    1. the Royalty Token does not represent a fractional ownership interest in any receivable, asset, licence or contractual right held by the Issuer, Royalty Provider or Royalty Supplier;
-    2. the Royalty Token only confers a contractual right to receive a Distribution, calculated according to the rules and formulas set out in these Token Terms and the applicable Particulars based on Royalty Payments received by Issuer;
-    3. the Royalty Token carries no other rights whatsoever, including, but not limited to, voting rights, dividend rights, rights to participate in rights issues or participation in shareholder meetings.
+   1. the Royalty Token does not represent a fractional ownership interest in any receivable, asset, licence or contractual right held by the Issuer, Royalty Provider or Royalty Supplier;
+   2. the Royalty Token only confers a contractual right to receive a Distribution, calculated according to the rules and formulas set out in these Token Terms and the applicable Particulars based on Royalty Payments received by Issuer;
+   3. the Royalty Token carries no other rights whatsoever, including, but not limited to, voting rights, dividend rights, rights to participate in rights issues or participation in shareholder meetings.
 2. Where control over a Royalty Token is transferred by way of crypto token transfer:
-    1. the transferring Party shall be deemed to have transferred all rights and obligations associated with that Royalty Token under these Token Terms;
-    2. the owner of the transferee Wallet shall automatically become subject to these Token Terms in place of the transferor, without the need for separate consent by the Issuer.
+   1. the transferring Party shall be deemed to have transferred all rights and obligations associated with that Royalty Token under these Token Terms;
+   2. the owner of the transferee Wallet shall automatically become subject to these Token Terms in place of the transferor, without the need for separate consent by the Issuer.
 
 ## 10. Legal Compliance of Investors
 
@@ -239,13 +238,13 @@ Finally, you represent that you will fully comply with all applicable laws and r
 
 1. The Investor bears the risk of any changes in law, regulation or tax regime, particularly the introduction of hydrocarbon-related taxes, that may reduce or eliminate Royalty Payments and, consequently, the Revenue Payments and Distributions derived therefrom. Such changes may occur without prior notice and are beyond the control of the Issuer, Royalty Supplier or Royalty Provider.
 2. Crypto transactions are irreversible. Investors accept the following risks associated with errors:
-    1. If a third party (e.g., an external service provider or wallet provider) makes an error, the Issuer is not liable for the resulting consequences, provided such third party is not acting as a vicarious agent (*Erfüllungsgehilfe*) or auxiliary person (*Verrichtungsgehilfe*) within the meaning of Applicable Law.
-    2. If the Issuer causes an error, the Investor may assert claims in accordance with statutory law and the clause at Reference 5 of these Token Terms.
+   1. If a third party (e.g., an external service provider or wallet provider) makes an error, the Issuer is not liable for the resulting consequences, provided such third party is not acting as a vicarious agent (_Erfüllungsgehilfe_) or auxiliary person (_Verrichtungsgehilfe_) within the meaning of Applicable Law.
+   2. If the Issuer causes an error, the Investor may assert claims in accordance with statutory law and the clause at Reference 5 of these Token Terms.
 3. Investors who acquire Royalty Tokens on the secondary market acknowledge that prior Distributions may, in rare cases, have been incorrectly calculated due to technical or administrative errors. Such errors may originate from third parties involved in the upstream payment chain, including the Royalty Provider or Royalty Supplier, who are not parties to the contractual relationship between the Investor and the Issuer. If such an error is identified after a Royalty Token has been transferred, the Issuer may, to the extent legally permissible and technically feasible, adjust future Distributions to reflect the correct allocation. Such adjustment shall only apply if it does not retroactively reduce legally vested claims and shall not be made if the error was caused by the Issuer’s, Royalty Provider’s or Royalty Supplier’s intent or gross negligence. The Issuer shall inform the affected Investors in a timely, clear, and transparent manner and shall document the reasons and method of correction.
 4. If the Royalty Provider is required to initiate legal action against the Royalty Supplier to enforce payment of due Royalty amounts, the following shall apply:
-    1. If the enforcement is successful and funds are recovered, whether in full or in part, the Royalty Provider is entitled to deduct only those legal costs that are (i) directly related to the enforcement of the Royalty Payments, (ii) objectively necessary and reasonable in amount, and (iii) supported by verifiable documentation. Any recovered amount will be transferred to the Issuer for onward Distribution to Investors in accordance with these Token Terms.
-    2. If the enforcement is unsuccessful and becomes a Permanent Payment Default, the Royalty Provider shall bear all legal costs. Investors shall not suffer any financial disadvantage as a result.
-    3. If the enforcement is temporarily unsuccessful but the default has not become a Permanent Payment Default, the Royalty Provider may offset the incurred legal costs proportionally against future Royalty Payments or instalment amounts recovered pursuant to an agreed payment schedule between the Royalty Provider and the Royalty Supplier, before forwarding them to the Issuer for Distribution to Investors. Such offsets may only occur in the course of ongoing Distributions and may not retroactively affect prior payouts. This clause does not entitle the Issuer to claim additional payments from Investors or to recover any previously distributed amounts.
+   1. If the enforcement is successful and funds are recovered, whether in full or in part, the Royalty Provider is entitled to deduct only those legal costs that are (i) directly related to the enforcement of the Royalty Payments, (ii) objectively necessary and reasonable in amount, and (iii) supported by verifiable documentation. Any recovered amount will be transferred to the Issuer for onward Distribution to Investors in accordance with these Token Terms.
+   2. If the enforcement is unsuccessful and becomes a Permanent Payment Default, the Royalty Provider shall bear all legal costs. Investors shall not suffer any financial disadvantage as a result.
+   3. If the enforcement is temporarily unsuccessful but the default has not become a Permanent Payment Default, the Royalty Provider may offset the incurred legal costs proportionally against future Royalty Payments or instalment amounts recovered pursuant to an agreed payment schedule between the Royalty Provider and the Royalty Supplier, before forwarding them to the Issuer for Distribution to Investors. Such offsets may only occur in the course of ongoing Distributions and may not retroactively affect prior payouts. This clause does not entitle the Issuer to claim additional payments from Investors or to recover any previously distributed amounts.
 5. The Investor shall not be entitled to derive any contractual or quasi-contractual rights or entitlements from, or assert any such rights or entitlements against, the Royalty Supplier based on the contractual relationship between the Royalty Provider and the Royalty Supplier. In particular, the contractual relationship between the Royalty Supplier and the Royalty Provider shall not give rise to any contractual or quasi-contractual rights or entitlements of the Investor.
 6. The Royalty Token system operates on blockchain-based infrastructure. Technical malfunctions, software bugs, or security incidents, such as smart contract exploits, oracle failures or consensus-level attacks, may impair or interrupt the functionality of the Royalty Tokens. The Issuer cannot guarantee the uninterrupted or error-free performance of blockchain networks or third-party infrastructure that is beyond their control. The Issuer shall implement industry-standard security measures to safeguard assets both on-chain and off-chain. Nevertheless, Investors acknowledge that the use of crypto-based payment systems involves certain inherent risks, including but not limited to losses resulting from hacking, fraud, or technical malfunctions outside the Issuer’s control. This does not affect the Issuer’s liability for damages caused by intent or gross negligence, or for the slightly negligent breach of material contractual obligations (cardinal duties). Further provisions on liability are set out in the clause at Reference 5 of these Token Terms.
 
@@ -253,7 +252,7 @@ Finally, you represent that you will fully comply with all applicable laws and r
 
 1. The Secured Claims of the Investors shall be secured by the Collateral granted by the Issuer and held by the Security Agent under the Collateral Agreement. Upon receipt by the Security Agent of a Notice Of Event Of Default and after a grace period of thirty (30) calendar days has expired and after the Security Agent has verified that an Event Of Default or an Insolvency Event in relation to the Issuer has occurred, the Security Agent shall enforce and manage the Collateral for the account (under a true contract for the benefit of third parties) of the Investors in accordance with the terms of the Collateral Agreement.
 2. The Security Agent shall be entitled, upon the occurrence of an Event Of Default, to enforce directly any assigned claims or enforcement rights against the Royalty Provider on behalf of the Investors, including by way of legal action or settlement. The Issuer shall provide the Security Agent with all necessary documentation and access to information required for enforcement. The Royalty Provider shall cooperate with the Security Agent in good faith and may not object to such enforcement on the basis of lacking privity of contract.
-3. The Security Agent is not a common representative of the Investors within the meaning of the German Debenture Bond Act (*Schuldverschreibungsgesetz*) and it is not liable under the provisions of the German Debenture Bond Act.
+3. The Security Agent is not a common representative of the Investors within the meaning of the German Debenture Bond Act (_Schuldverschreibungsgesetz_) and it is not liable under the provisions of the German Debenture Bond Act.
 4. The Security Agent shall receive from the Issuer during the term of the Collateral Agreement an appropriate remuneration as well as reimbursement of its expenses, fees and disbursements incurred in connection with the Collateral Agreement.
 5. The Collateral Agreement provides that upon the occurrence of an Event Of Default or an Insolvency Event relating to the Issuer the Collateral cannot be realised by the Issuer. If none of these events is occurring, the Issuer may access and realise the Collateral.
 6. By investing in the Royalty Tokens, each Investor expressly agrees and acknowledges that the Issuer shall appoint the Security Agent to act on behalf of the Investors for the purpose of holding and enforcing the collateral, as further specified in and subject to the terms and conditions of the Collateral Terms (Schedule 1) of the Collateral Agreement.
@@ -263,11 +262,11 @@ Finally, you represent that you will fully comply with all applicable laws and r
 ## 13. Liability [REFERENCE 5]
 
 1. The Issuer shall be liable without limitation only for damages suffered by the Investor that:
-    1. are caused by an intentional or grossly negligent breach of duty by the Issuer its legal representatives or vicarious agents; or
-    2. result from the slightly negligent breach of a material contractual obligation (*cardinal duty*). In this case, the Issuer’s liability shall be limited to the foreseeable damage typical for the type of contract. Cardinal duties are obligations whose fulfilment is essential for the proper execution of the Token Terms and on which the Investor regularly relies.
+   1. are caused by an intentional or grossly negligent breach of duty by the Issuer its legal representatives or vicarious agents; or
+   2. result from the slightly negligent breach of a material contractual obligation (_cardinal duty_). In this case, the Issuer’s liability shall be limited to the foreseeable damage typical for the type of contract. Cardinal duties are obligations whose fulfilment is essential for the proper execution of the Token Terms and on which the Investor regularly relies.
 2. The Issuer shall not be liable for defects, malfunctions or failures of any blockchain, smart contracts or other technical infrastructure operated by third parties beyond their control. This includes, in particular, losses due to errors, delays, or interruptions in blockchain-based transactions. The Issuer shall also not be liable for the loss of off-chain assets or on-chain tokens, unless such loss was caused by intentional misconduct or gross negligence. Liability for data loss is limited to typical recovery costs that would have been incurred with appropriate, risk-based data backup.
 3. Any further liability of the Issuer is excluded to the extent permitted by law. This limitation also applies to the personal liability of their employees, representatives and vicarious agents, including liability in tort.
-4. The above exclusions and limitations of liability shall not apply in cases of injury to life, body or health, in the event of liability under mandatory statutory provisions, particularly the German Product Liability Act (*Produkthaftungsgesetz*) or where a guarantee to the Investor has been expressly assumed.
+4. The above exclusions and limitations of liability shall not apply in cases of injury to life, body or health, in the event of liability under mandatory statutory provisions, particularly the German Product Liability Act (_Produkthaftungsgesetz_) or where a guarantee to the Investor has been expressly assumed.
 5. The limitation period for all warranty claims of the Investor shall be twelve (12) months, unless longer periods are required by mandatory law. This does not apply if the Investor is a consumer within the meaning of § 13 BGB; in such cases, the statutory limitation periods shall remain unaffected.
 
 ## 14. Force Majeure
@@ -280,22 +279,23 @@ Finally, you represent that you will fully comply with all applicable laws and r
 ## 15. Substitution of the Issuer
 
 The Issuer may, without the prior consent of the Investors, substitute itself in relation to all rights and obligations under these Token Terms with another legal entity (the “**New Issuer**”), provided that:
+
 1. the New Issuer is objectively capable of performing all obligations arising from or in connection with these Token Terms;
 2. the existing Issuer provides an irrevocable and unconditional guarantee to Investors for the full and timely performance of the New Issuer’s obligations under these Token Terms;
 3. such substitution does not materially impair the legal position of the Investors, in particular with regard to:
-    1. the enforceability of rights under these Token Terms,
-    2. the applicable regulatory protections, and
-    3. the Investor's ability to receive Distributions.
+   1. the enforceability of rights under these Token Terms,
+   2. the applicable regulatory protections, and
+   3. the Investor's ability to receive Distributions.
 
 Investors shall be informed of any substitution without undue delay through the communication procedure set out in the clause at Reference 6.
 
 ## 16. Amendments of the Token Terms
 
 1. The Issuer shall be entitled to amend or supplement the Token Terms without the prior consent of the Investors, provided that such amendment or supplementation:
-    1. is necessary to correct manifest clerical or factual errors;
-    2. serves to clarify ambiguous or unclear provisions without changing the substantive rights or obligations of the Investors; or
-    3. is necessary to adapt to technical, legal, or regulatory developments, provided such change does not materially prejudice the Investor’s legal or financial position and is transparently communicated. The Issuer shall provide reasons for such an amendment; or
-    4. is required by binding legal provisions, final judicial decisions, or binding administrative orders.
+   1. is necessary to correct manifest clerical or factual errors;
+   2. serves to clarify ambiguous or unclear provisions without changing the substantive rights or obligations of the Investors; or
+   3. is necessary to adapt to technical, legal, or regulatory developments, provided such change does not materially prejudice the Investor’s legal or financial position and is transparently communicated. The Issuer shall provide reasons for such an amendment; or
+   4. is required by binding legal provisions, final judicial decisions, or binding administrative orders.
 2. If the amendment affects material provisions of the Token Terms, including rights, obligations, or the economic position of the Investors, such amendment shall only take effect if the Investor has expressly agreed to the amendment in advance. The Issuer shall provide the Investor with the proposed amendment in text form, explaining the reasons for the change. The Issuer may ask the Investor to provide consent electronically or in writing. If the Investor does not consent, the existing Token Terms shall continue to apply. The Issuer reserves the right to terminate the agreement with six (6) weeks’ notice, provided that continuation of the agreement would be unreasonable for the Issuer. In cases where a Investor refuses to consent to a material amendment pursuant to this section, the Issuer may offer to redeem the affected Royalty Tokens at their fair market value in USDT, provided the redemption terms are transparent, objectively verifiable and not disadvantageous to the Investors. Redemption shall be made to the Investor’s last known wallet address.
 3. For the avoidance of doubt, the version of the Token Terms applicable to a specific Royalty Token Release shall be the version in force at the time of that Royalty Token Release.
 
@@ -355,6 +355,7 @@ means the pro-rata payments equal to the Total Distribution divided by the Royal
 ## 8. Event Of Default
 
 means any of the conditions or events described with reference to clause Reference 7, which shall be deemed to constitute an Event Of Default if and for so long as they shall have occurred and be continuing:
+
 1. The Issuer fails to pay any amount in respect to the Royalty Tokens when due and payable in a commercial reasonable timeframe, including as a result of not having received the corresponding Royalty Payments from the Royalty Provider;
 2. an Insolvency Event in relation to the Issuer.
 
@@ -369,6 +370,7 @@ means the framework agreement between the Royalty Provider and the Issuer govern
 ## 11. Government Licence
 
 means the government licence granted to an entity to extract oil from the Oil Well, which regulates the:
+
 1. Wellbore; and
 2. the associated equipment, casing, and surface facilities.
 
@@ -383,9 +385,10 @@ means the aggregate gross revenue received by arising by or on behalf of Royalty
 ## 14. Insolvency Event
 
 means the occurrence of any of the following events in relation to any entity relevant to the performance of obligations under these Terms:
-1. is unable or is expected to be unable to pay its debts as they fall due (*Zahlungsunfähigkeit* or *drohende Zahlungsunfähigkeit*) within the meaning of Section 17 para. 2 or 18 para. 2 of the German Insolvency Code (*Insolvenzordnung*), or admits its inability to pay its debts as they fall due or insofar as it does not have its seat in the Federal Republic of Germany, is insolvent, admits its inability to pay its debts as they fall due or it generally discontinues payment to its debtors;
-2. is over-indebted (*überschuldet*) within the meaning of Section 19 of the German Insolvency Code (*Insolvenzordnung*) or insofar as it does not have its seat in the Federal Republic of Germany, its liabilities (taking into account conditional and future liabilities) exceed its assets;
-3. for any of the reasons set out in Sections 17 to 19 of the German Insolvency Code (*Insolvenzordnung*), files for insolvency (*Antrag auf Eröffnung eines Insolvenzverfahrens*) (also in cases of self-management of administration (*Eigenverwaltung*) against its assets) or its board members (*Vorstände*) or directors (*Geschäftsführer*) are required by law to file for insolvency, or a creditor files for the opening of insolvency proceedings (other than a petition or application which is vexatious or frivolous and which is discharged, stayed or dismissed within fourteen (14) Business Days of application); or
+
+1. is unable or is expected to be unable to pay its debts as they fall due (_Zahlungsunfähigkeit_ or _drohende Zahlungsunfähigkeit_) within the meaning of Section 17 para. 2 or 18 para. 2 of the German Insolvency Code (_Insolvenzordnung_), or admits its inability to pay its debts as they fall due or insofar as it does not have its seat in the Federal Republic of Germany, is insolvent, admits its inability to pay its debts as they fall due or it generally discontinues payment to its debtors;
+2. is over-indebted (_überschuldet_) within the meaning of Section 19 of the German Insolvency Code (_Insolvenzordnung_) or insofar as it does not have its seat in the Federal Republic of Germany, its liabilities (taking into account conditional and future liabilities) exceed its assets;
+3. for any of the reasons set out in Sections 17 to 19 of the German Insolvency Code (_Insolvenzordnung_), files for insolvency (_Antrag auf Eröffnung eines Insolvenzverfahrens_) (also in cases of self-management of administration (_Eigenverwaltung_) against its assets) or its board members (_Vorstände_) or directors (_Geschäftsführer_) are required by law to file for insolvency, or a creditor files for the opening of insolvency proceedings (other than a petition or application which is vexatious or frivolous and which is discharged, stayed or dismissed within fourteen (14) Business Days of application); or
 4. agrees to or declares a moratorium, or enters into any composition, compromise, arrangement, settlement or standstill agreement with any of its creditors in anticipation of financial difficulties.
 
 ## 15. Interface
@@ -430,7 +433,8 @@ means the portion of a Royalty Payment that is not subject to a Royalty Token Re
 
 ## 25. Permanent Payment Default
 
-means a situation in which 
+means a situation in which
+
 1. no material recovery has been made within eighteen (18) months following the initial enforcement attempt despite reasonable efforts; or
 2. an Insolvency Event relating to the Royalty Supplier has occurred; or
 3. a court has issued a final and binding decision confirming that recovery of the due Royalty amounts is not possible.
@@ -502,6 +506,7 @@ means the agent acting as representative of the Investors who, in its own name b
 ## 42. Security Event
 
 means any security-related incident that compromises or threatens the technical functionality, legal integrity or economic model of the Royalty Token or associated infrastructure. A Security Event includes, but is not limited to:
+
 1. exploitation of bugs, vulnerabilities, or unintended functionality in the Royalty Token smart contract or any connected contracts such as treasury, snapshot, or distribution mechanisms;
 2. unauthorized deployment of or interaction with malicious smart contracts targeting the Royalty Token or related smart contract components (e.g., snapshot, airdrop or vault mechanisms);
 3. economic exploits such as flash loan attacks, re-entrancy attacks, or arbitrage-driven manipulations in the context of token allocation or trading functionality;
@@ -518,6 +523,7 @@ means the digital construct and permissions, implemented by smart contracts, man
 ## 44. Snapshot, Snapshots
 
 means a data snapshot of the relevant blockchain to determine the state of the blockchain in terms of:
+
 1. Royalty Token holdings; and
 2. for Variable Royalty Tokens, the supply,
 
@@ -579,7 +585,7 @@ means the borehole designated in the applicable Project Agreement as the source 
 4. **"Event Of Default"** in relation to the Issuer as specified in the Token Terms.
 5. **"Insolvency Event"** in relation to the Issuer as specified in the Token Terms.
 6. **"Investor, Investors"** means an investor by way of a Royalty Token holding.
-7. **"Issuer"** means S01 Issuer GmbH, Kurfürstendamm 15, 10719 Berlin, Federal Republic of Germany, registered in the commercial register (*Handelsregister*) of the local court (*Amtsgericht*) of Berlin-Charlottenburg under the registration number HRB 270925 B.
+7. **"Issuer"** means S01 Issuer GmbH, Kurfürstendamm 15, 10719 Berlin, Federal Republic of Germany, registered in the commercial register (_Handelsregister_) of the local court (_Amtsgericht_) of Berlin-Charlottenburg under the registration number HRB 270925 B.
 8. **"Net Realization Proceeds"** means the amount resulting of the deduction of the service fees and additional costs of the Security Agent from the realization proceeds.
 9. **"Notice Of Event Of Default"** means, if applicable according to the Token Terms, a written notice by the Issuer or by an Investor delivered to the Security Agent, stating that an Event Of Default, or an Insolvency Event has occurred and is continuing.
 10. **"Parties"** means the Issuer and the Security Agent.
@@ -627,10 +633,10 @@ Notwithstanding anything to the contrary herein, no recourse (whether by institu
 ### 8. Replacement of Security Agent
 
 1. The Security Agent may resign at any time by notifying the Issuer in writing not less than ninety (90) days prior to the effective date of such resignation. The Issuer shall remove the Security Agent if:
-    1. the Security Agent fails to comply with its obligations;
-    2. the Security Agent is adjudged as bankrupt or insolvent;
-    3. a receiver or other public officer takes charge of the Security Agent or its property; or
-    4. the Security Agent otherwise becomes incapable of acting.
+   1. the Security Agent fails to comply with its obligations;
+   2. the Security Agent is adjudged as bankrupt or insolvent;
+   3. a receiver or other public officer takes charge of the Security Agent or its property; or
+   4. the Security Agent otherwise becomes incapable of acting.
 2. If the Security Agent resigns or is removed for any reason, the Issuer shall promptly appoint a successor Security Agent.
 3. Any successor Security Agent shall deliver a written acceptance of its appointment to the retiring Security Agent and to the Issuer. Thereupon, the resignation or removal of the retiring Security Agent shall become effective, and the successor Security Agent shall have all the rights, powers and duties of the Security Agent under this Agreement. The retiring Security Agent shall promptly transfer all property held by it as Security Agent to the successor Security Agent.
 
@@ -639,7 +645,7 @@ Notwithstanding anything to the contrary herein, no recourse (whether by institu
 1. This Agreement is governed by and shall be construed in accordance with the substantive laws of Germany (excluding any conflict of laws rules).
 2. The place of performance and sole legal venue for all disputes arising from the legal relationships regulated under this Collateral Agreement is Berlin.
 3. No waiver or variation of any part of this Agreement shall be effective unless in writing. No waiver of any provision in this Agreement will be deemed a waiver of a subsequent breach of such provision or a waiver of a similar provision. In addition, a waiver of any breach or a failure to enforce any term or condition of this Agreement will not in any way affect, limit, or waive our rights hereunder at any time to enforce strict compliance thereafter with every term and condition of this Agreement.
-4. If any provision of this Agreement should be or become invalid or unenforceable in whole or in part, this shall indisputably (*unwiderlegbar*) not affect the validity of the balance of this Agreement. The invalid or unenforceable provision shall be deemed replaced by such provision which best meets the intent and the economic purpose of the invalid or unenforceable provision. The same shall apply mutatis mutandis in case of omissions (*Vertragslücken*).
+4. If any provision of this Agreement should be or become invalid or unenforceable in whole or in part, this shall indisputably (_unwiderlegbar_) not affect the validity of the balance of this Agreement. The invalid or unenforceable provision shall be deemed replaced by such provision which best meets the intent and the economic purpose of the invalid or unenforceable provision. The same shall apply mutatis mutandis in case of omissions (_Vertragslücken_).
 
 # Schedule 2 - Framework Revenue Purchase Agreement Summary
 
@@ -651,7 +657,7 @@ Notwithstanding anything to the contrary herein, no recourse (whether by institu
 
 **Release Token Terms** means the specific Token Terms document accompanying an offer to enter into a Revenue Purchase Agreement by Albion, which will be substantially in the form of the Token Terms.
 
-**Royalty Supplier** means EUROPA OIL & GAS LTD, a company incorporated in England and Wales with company number 03093716 with a registered office at 54 Charlotte Street, London W1T 2NS, England. 
+**Royalty Supplier** means EUROPA OIL & GAS LTD, a company incorporated in England and Wales with company number 03093716 with a registered office at 54 Charlotte Street, London W1T 2NS, England.
 
 **Token Terms** means [x]
 
@@ -665,22 +671,22 @@ Notwithstanding anything to the contrary herein, no recourse (whether by institu
 
 **A. Offers**
 
-1. Albion is required to issue to the Issuer a binding offer for the conclusion of Revenue Purchase Agreement(s). 
-2. Each offer is to include the parameters for the agreement, including: 
-    1. the relevant purchase price;
-    2. the purchase payment period;
-    3. the revenue payment start date;
-    4. the revenue payment percentage; and 
-    5. any special conditions (which override the terms of the Agreement to the extent of any inconsistency). 
-3. The offer must also set out the Release Token Terms and the following particulars which are to be derived from the Token Terms: 
-    1. the royalty payment percentage; 
-    2. royalty token price; 
-    3. payment token exclusive;
-    4. supply type; 
-    5. supply limit; and
-    6. management fees. 
+1. Albion is required to issue to the Issuer a binding offer for the conclusion of Revenue Purchase Agreement(s).
+2. Each offer is to include the parameters for the agreement, including:
+   1. the relevant purchase price;
+   2. the purchase payment period;
+   3. the revenue payment start date;
+   4. the revenue payment percentage; and
+   5. any special conditions (which override the terms of the Agreement to the extent of any inconsistency).
+3. The offer must also set out the Release Token Terms and the following particulars which are to be derived from the Token Terms:
+   1. the royalty payment percentage;
+   2. royalty token price;
+   3. payment token exclusive;
+   4. supply type;
+   5. supply limit; and
+   6. management fees.
 4. The offer must also include other relevant information including the pending distributions.
-5. Albion shall be bound by each offer for a period of five calendar days from the date of receipt by the Issuer, unless a different binding period is expressly stated in the offer. 
+5. Albion shall be bound by each offer for a period of five calendar days from the date of receipt by the Issuer, unless a different binding period is expressly stated in the offer.
 
 **B. Acceptance**
 
@@ -691,7 +697,7 @@ Notwithstanding anything to the contrary herein, no recourse (whether by institu
 **C. Purchase Price Payment**
 
 1. The purchase price under each Revenue Purchase Agreement is determined based on the revenue payment percentage applied to the royalty payments that Albion receives from the Royalty Supplier.
-2. The purchase price is due from the Issuer by no later than the 10th day of each calendar month during the payment period for the relevant Revenue Purchase Agreement. It is to be calculated on a pro-rata basis by reference to the number of months in the payment period. 
+2. The purchase price is due from the Issuer by no later than the 10th day of each calendar month during the payment period for the relevant Revenue Purchase Agreement. It is to be calculated on a pro-rata basis by reference to the number of months in the payment period.
 3. Issuer’s obligation to pay the Purchase Price is suspended when Albion does not pay the revenue payments by the due date, until Albion resumes the revenue payments.
 4. Payment shall be made in US Dollar tokens to the wallet address nominated by Albion.
 
@@ -700,32 +706,33 @@ Notwithstanding anything to the contrary herein, no recourse (whether by institu
 **A. Notification and information requests**
 
 1. Albion shall promptly inform the Issuer of all royalty payments received from the Royalty Supplier to the extent such payments are relevant for calculating and transferring
-revenue payments to the Issuer. 
-2. The Issuer shall be entitled to request reasonable supporting documentation. 
+   revenue payments to the Issuer.
+2. The Issuer shall be entitled to request reasonable supporting documentation.
 3. The Issuer may also, at its own expense, have certain records of Albion reviewed by an independent auditor.
 
 **B. Revenue payment terms**
 
-1. Albion undertakes to pay the revenue payments (including any pending distributions) to the Issuer within five business days after Albion's receipt of the corresponding royalty payments from the Royalty Supplier. 
+1. Albion undertakes to pay the revenue payments (including any pending distributions) to the Issuer within five business days after Albion's receipt of the corresponding royalty payments from the Royalty Supplier.
 2. Payments must be in the currency specified by the Issuer and to the bank account or wallet details notified by the Issuer.
 
 **C. Notification of material events**
 
 Albion shall promptly notify the Issuer of any material event in relation to the royalty payments which may affect the revenue payments.
 
-### 5. Termination 
+### 5. Termination
 
 1. The Agreement shall continue for an indefinite period and may be terminated by either Party upon five days' notice.
-2. The Parties may also terminate the Agreement for cause. 
+2. The Parties may also terminate the Agreement for cause.
 
-### 6. Albion's limitation of liability 
-1. Albion's liability is limited as follows: 
-    1. liability is excluded except in cases of intent or gross negligence;
-    2. where Albion has been slightly negligent in respect of a cardinal obligation under the Agreement, its liability is limited to such damages as are foreseeable and typical, and the liability is limited to compensation of direct damages only;
-    3. Albion's liability for culpable injury to life, body or health as well as liability under the German Product Liability Act is not limited; and
-    4. Albion's liability for damage for one or more breaches of duty is limited to the amount of royalty payments actually received in the twelve months preceding the relevant event and will not in any event exceed $50,000.
+### 6. Albion's limitation of liability
 
-### 7. Governing Law 
+1. Albion's liability is limited as follows:
+   1. liability is excluded except in cases of intent or gross negligence;
+   2. where Albion has been slightly negligent in respect of a cardinal obligation under the Agreement, its liability is limited to such damages as are foreseeable and typical, and the liability is limited to compensation of direct damages only;
+   3. Albion's liability for culpable injury to life, body or health as well as liability under the German Product Liability Act is not limited; and
+   4. Albion's liability for damage for one or more breaches of duty is limited to the amount of royalty payments actually received in the twelve months preceding the relevant event and will not in any event exceed $50,000.
+
+### 7. Governing Law
 
 The governing law of the Agreement is the law of Germany and the courts of Berlin, Germany have exclusive jurisdiction to settle any disputes arising from the Agreement.
 
@@ -737,7 +744,7 @@ The governing law of the Agreement is the law of Germany and the courts of Berli
 
 **Co-venturers** means any of the parties to the Joint Operating Agreement in place from time to time (other than Europa or its Affiliates).
 
-**Gross Revenue** means the aggregate gross revenue arising (including any prepayments received for production to be delivered in the future) during the term of the Agreement by or on behalf of Europa, its affiliates and/or the Co-venturers or their affiliates from all petroleum produced from the Oil Well without deduction of applicable tax (but which may include deductions for value added tax and any future hydrocarbon revenue tax). If petroleum is sold to affiliates of Europa or the Co-venturers or otherwise not on arm's length, the relevant gross revenue will be deemed to be the greater of the value received and the market value of the petroleum sold. Similarly, where petroleum is sold for non-cash consideration, the gross revenue for that petroleum will be the greater of the fair market value of that non-cash consideration and the market value of the petroleum sold. 
+**Gross Revenue** means the aggregate gross revenue arising (including any prepayments received for production to be delivered in the future) during the term of the Agreement by or on behalf of Europa, its affiliates and/or the Co-venturers or their affiliates from all petroleum produced from the Oil Well without deduction of applicable tax (but which may include deductions for value added tax and any future hydrocarbon revenue tax). If petroleum is sold to affiliates of Europa or the Co-venturers or otherwise not on arm's length, the relevant gross revenue will be deemed to be the greater of the value received and the market value of the petroleum sold. Similarly, where petroleum is sold for non-cash consideration, the gross revenue for that petroleum will be the greater of the fair market value of that non-cash consideration and the market value of the petroleum sold.
 
 **Joint Operating Agreement** means any joint operating agreement entered into between two or more parties to the Licence in respect of governance, development, operation and/or abandonment of the Oil Well and at the time of this summary means the _Joint Operating Agreement_ dated 1 October 2008, as supplemented, amended and/or varied, from time to time.
 
@@ -799,13 +806,13 @@ Europa expressly acknowledges that Albion may tokenise the Royalty Interest for 
 
 **H. Guarantee and Indemnity**
 
-Europa guarantees to Albion the punctual performance of its obligations under the Agreement. Europa also indemnifies Albion up to the amount it would have had to pay under the guarantee if any guaranteed obligation is or becomes unenforceable, invalid or illegal. 
+Europa guarantees to Albion the punctual performance of its obligations under the Agreement. Europa also indemnifies Albion up to the amount it would have had to pay under the guarantee if any guaranteed obligation is or becomes unenforceable, invalid or illegal.
 
 **I. Europa Warranties and Obligations Concerning the Oil Well**
 
 Europa provides various warranties to Albion that apply during the term of the Agreement. These include warranting that it has title to the petroleum, that there are no events or circumstances connected to the Licence or Joint Operating Agreement that pose a material risk to the Licence or Joint Operating Agreement, and that there are no encumbrances over the petroleum.
 
-Europa is required to perform its obligations under the Licence and Joint Operating Agreement and to notify Albion of events or circumstances that pose a material risk to the Licence or Joint Operating Agreement. 
+Europa is required to perform its obligations under the Licence and Joint Operating Agreement and to notify Albion of events or circumstances that pose a material risk to the Licence or Joint Operating Agreement.
 
 Europa is prohibited from terminating or varying the Licence, granting certain encumbrances over the Licence or Joint Operating Agreement, surrendering or abandoning all of part of the Licence or Licence area, or decommissioning or abandoning the Oil Well or its facilities unless required by Law or the North Sea Transition Authority.
 
@@ -828,11 +835,11 @@ The Royalty Interest will terminate on the earlier of:
 
 1. 31 December 2029; or
 2. on the occurrence of any of the following events:
-	- the termination or relinquishment of the Licence as required by law or the North Sea Transition Authority;
-	- a capital expenditure of more than $200,000 in the Oil Well after 31 December 2027; 
-	- the Side Tracking of the Oil Well; 
-    1. Albion terminating the Agreement following the occurrence of certain insolvency-related events; or
-    2. the parties agreeing to terminate the Agreement.
+   - the termination or relinquishment of the Licence as required by law or the North Sea Transition Authority;
+   - a capital expenditure of more than $200,000 in the Oil Well after 31 December 2027;
+   - the Side Tracking of the Oil Well;
+   1. Albion terminating the Agreement following the occurrence of certain insolvency-related events; or
+   2. the parties agreeing to terminate the Agreement.
 
 **O. Sale or Change of Control**
 


### PR DESCRIPTION
## Problem

   - Token minting was failing intermittently due to a race condition:
   - The approval transaction was initiated but not fully confirmed before attempting the deposit
   - RPC nodes may not have synced the approval state when the deposit was attempted
   - Users had no visibility into the transaction hash after a successful mint

   ## Solution

   ### Transaction Confirmation Fix
   - Added `confirmations: 2` to wait for 2 block confirmations on the ERC20 approval transaction
   - Added 1-second delay after confirmation to ensure RPC nodes have synced the approval state

   ### User Experience Enhancement
   - Capture the deposit transaction hash on successful mint
   - Display transaction hash in the success modal
   - Add clickable Basescan link to view the transaction on-chain

   ## Testing

   - Verified token minting completed once.