### PR TITLE
Add 2026-02 rewards claims data

### DIFF
--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -177,6 +177,15 @@ const PROD_ENERGY_FIELDS: EnergyField[] = [
               "0x48a0516de0526f297387bcfef79b2f3206eca52ff97fc0977d73b31c73ee93e0",
             expectedContentHash:
               "bafkreib2f2jdrvugwbz5fyd5xdvehnae73eiqkjjurkecmq73z2lxbwmqy",
+          },
+          {
+            orderHash:
+              "0x3b976cdb37e00c214fd7212abd052e5da0760e39f0c8d9631ac122a13c3b4b44",
+            csvLink: `${PINATA_GATEWAY}/bafkreia2ebr2wyuga3d4t6yqwcbbs65hqtqyyycnuo24wj5zo4ikurly7m`,
+            expectedMerkleRoot:
+              "0x12b0ad087ddbcd90388c110ecc52079140e0d94dfc319ca9231e25a3f8dd0d6e",
+            expectedContentHash:
+              "bafkreia2ebr2wyuga3d4t6yqwcbbs65hqtqyyycnuo24wj5zo4ikurly7m",
           }
         ],
       },
@@ -210,6 +219,15 @@ const PROD_ENERGY_FIELDS: EnergyField[] = [
               "0x48c657bb2fe1fed058112dc5d70c260cb5a0e84722f94a1ad236a5b54efa1f76",
             expectedContentHash:
               "bafkreie3wns4i6tp62fytgt5wgf27igzttabqf3jn6ddmkvrvyowqcc5oq",
+          },
+          {
+            orderHash:
+              "0xc0b5da036283d08ff457b4146198e66ed1e81a3f7da67d638b3a3c40a9a92f5e",
+            csvLink: `${PINATA_GATEWAY}/bafkreibnu7oa7rbcm5jzpbxzndobgxzj4pvhx6eptcdl6lhgbw7rredd6e`,
+            expectedMerkleRoot:
+              "0xa8a356b9271f046e713394ef57c0c33ec5193156b824ba457a74fd50935c6883",
+            expectedContentHash:
+              "bafkreibnu7oa7rbcm5jzpbxzndobgxzj4pvhx6eptcdl6lhgbw7rredd6e",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Add February 2026 R1 and R2 claims entries to `PROD_ENERGY_FIELDS` in `network.ts`
- R1 orderHash: `0x3b976cdb37e00c214fd7212abd052e5da0760e39f0c8d9631ac122a13c3b4b44`
- R2 orderHash: `0xc0b5da036283d08ff457b4146198e66ed1e81a3f7da67d638b3a3c40a9a92f5e`

## Test plan
- [ ] Verify claims page loads correctly with new entries
- [ ] Test claiming flow for both R1 and R2 tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)