### PR TITLE
perf(claims): speed up Claims & Portfolio load (stacked on #172)

### DIFF
--- a/src/lib/services/ClaimsService.ts
+++ b/src/lib/services/ClaimsService.ts
@@ -158,6 +158,8 @@ export class ClaimsService {
       refreshContextEvents?: boolean;
       /** Recent claim tx hashes for receipt-log fallback (e.g. after a successful claim). */
       claimTxHashes?: string[];
+      /** Called after each claim batch completes so the UI can render incrementally. */
+      onPartialResult?: (partial: ClaimsResult) => void;
     },
   ): Promise<ClaimsResult> {
     if (!ownerAddress) {
@@ -242,6 +244,14 @@ export class ClaimsService {
       }
     }
 
+    const claimBlock = (claim: Claim): number => {
+      if (claim.deployBlock !== undefined) return claim.deployBlock;
+      const order = ordersByHash.get(claim.orderHash.toLowerCase());
+      const blockNum = order?.addEvents?.[0]?.transaction?.blockNumber;
+      return blockNum ? parseInt(blockNum) : 0;
+    };
+    claimMetadata.sort((a, b) => claimBlock(b.claim) - claimBlock(a.claim));
+
     const storedClaimTxHashes = [
       ...new Set([
         ...getStoredClaimTransactionHashes(),
@@ -303,36 +313,62 @@ export class ClaimsService {
           ),
     );
 
-    // Process claims in batches (6 at a time with 100ms delay between batches)
-    const results = await this.processBatch(claimProcessors, 6, 100);
+    const batchSize = 8;
+    const delayBetweenBatches = 50;
+    const emitPartial = () => {
+      options?.onPartialResult?.({
+        holdings: [...holdings],
+        claimHistory: [...claimHistory],
+        totals: {
+          earned: totalEarned,
+          claimed: totalClaimed,
+          unclaimed: totalUnclaimed,
+        },
+        hasCsvLoadError: csvLoadFailed,
+      });
+    };
 
-    for (let index = 0; index < results.length; index += 1) {
-      const result = results[index];
+    for (let i = 0; i < claimProcessors.length; i += batchSize) {
+      const batch = claimProcessors.slice(i, i + batchSize);
+      const batchResults = await Promise.allSettled(batch.map((fn) => fn()));
 
-      if (result.status === "rejected") {
-        console.error("Error processing claim:", result.reason);
-        csvLoadFailed = true;
-        continue;
+      for (let batchIndex = 0; batchIndex < batchResults.length; batchIndex += 1) {
+        const result = batchResults[batchIndex];
+        const metadataIndex = i + batchIndex;
+
+        if (result.status === "rejected") {
+          console.error("Error processing claim:", result.reason);
+          csvLoadFailed = true;
+          continue;
+        }
+
+        const claimData = result.value;
+        if (!claimData) continue;
+
+        const { fieldName, tokenAddress, symbol } = claimMetadata[metadataIndex];
+
+        claimHistory = [...claimHistory, ...claimData.claims];
+
+        this.mergeHoldingsGroup(
+          holdings,
+          fieldName,
+          tokenAddress,
+          symbol,
+          claimData.holdings,
+        );
+
+        totalClaimed += claimData.totalClaimed;
+        totalEarned += claimData.totalEarned;
+        totalUnclaimed += claimData.totalUnclaimed;
       }
 
-      const claimData = result.value;
-      if (!claimData) continue;
+      emitPartial();
 
-      const { fieldName, tokenAddress, symbol } = claimMetadata[index];
-
-      claimHistory = [...claimHistory, ...claimData.claims];
-
-      this.mergeHoldingsGroup(
-        holdings,
-        fieldName,
-        tokenAddress,
-        symbol,
-        claimData.holdings,
-      );
-
-      totalClaimed += claimData.totalClaimed;
-      totalEarned += claimData.totalEarned;
-      totalUnclaimed += claimData.totalUnclaimed;
+      if (i + batchSize < claimProcessors.length) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, delayBetweenBatches),
+        );
+      }
     }
 
     return {

--- a/src/lib/stores/claimsCache.ts
+++ b/src/lib/stores/claimsCache.ts
@@ -7,7 +7,35 @@ interface CacheEntry {
   address: string;
 }
 
-const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+const MEMORY_TTL = 5 * 60 * 1000; // 5 minutes — in-memory fast path
+const SESSION_TTL = 30 * 60 * 1000; // 30 minutes — sessionStorage persistence
+const STORAGE_KEY = "albion-claims-cache";
+
+function readSessionEntry(address: string): CacheEntry | null {
+  if (typeof sessionStorage === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as CacheEntry;
+    if (entry.address !== address) return null;
+    if (Date.now() - entry.timestamp > SESSION_TTL) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionEntry(entry: CacheEntry) {
+  if (typeof sessionStorage === "undefined") return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+  } catch {
+    // Quota exceeded or private browsing — in-memory cache still works
+  }
+}
 
 function createClaimsCache() {
   const store = writable<CacheEntry | null>(null);
@@ -17,33 +45,61 @@ function createClaimsCache() {
 
     get(address: string): ClaimsResult | null {
       const cache = get(store);
-      if (!cache || cache.address !== address) return null;
-
-      const age = Date.now() - cache.timestamp;
-      if (age > CACHE_DURATION) {
+      if (cache && cache.address === address) {
+        const age = Date.now() - cache.timestamp;
+        if (age <= SESSION_TTL) return cache.data;
         store.set(null);
-        return null;
       }
 
-      return cache.data;
+      const sessionEntry = readSessionEntry(address);
+      if (sessionEntry) {
+        store.set(sessionEntry);
+        return sessionEntry.data;
+      }
+
+      return null;
     },
 
     set(address: string, data: ClaimsResult) {
-      store.set({
+      const entry: CacheEntry = {
         data,
         address,
         timestamp: Date.now(),
-      });
+      };
+      store.set(entry);
+      writeSessionEntry(entry);
     },
 
     clear() {
       store.set(null);
+      if (typeof sessionStorage !== "undefined") {
+        try {
+          sessionStorage.removeItem(STORAGE_KEY);
+        } catch {
+          // ignore
+        }
+      }
+    },
+
+    /** True when cached data exists and is older than the in-memory TTL (stale-while-revalidate). */
+    isStale(address: string): boolean {
+      const cache = get(store);
+      if (cache && cache.address === address) {
+        return Date.now() - cache.timestamp >= MEMORY_TTL;
+      }
+      const sessionEntry = readSessionEntry(address);
+      if (sessionEntry) {
+        return Date.now() - sessionEntry.timestamp >= MEMORY_TTL;
+      }
+      return false;
     },
 
     isValid(address: string): boolean {
       const cache = get(store);
-      if (!cache || cache.address !== address) return false;
-      return Date.now() - cache.timestamp < CACHE_DURATION;
+      if (cache && cache.address === address) {
+        return Date.now() - cache.timestamp < MEMORY_TTL;
+      }
+      return readSessionEntry(address) !== null;
     },
   };
 }

--- a/src/routes/(main)/claims/+page.svelte
+++ b/src/routes/(main)/claims/+page.svelte
@@ -29,7 +29,7 @@
 	} from '$lib/utils/claimExecution';
 	import type { Hex } from 'viem';
 	import { claimsCache } from '$lib/stores/claimsCache';
-	import type { ClaimsHoldingsGroup } from '$lib/services/ClaimsService';
+	import type { ClaimsHoldingsGroup, ClaimsResult } from '$lib/services/ClaimsService';
 	import {
 		recordClaimTransactionHashes,
 		type ClaimHistory
@@ -41,6 +41,7 @@
 	let totalClaimed = 0;
 	let unclaimedPayout = 0;
 	let pageLoading = true;
+	let claimsRefreshing = false;
 	let claimingTarget: 'all' | string | null = null; // 'all' for claim all, token address for single, null for none
 	let confirmingTarget: 'all' | string | null = null;
 	let verifyingTarget: 'all' | string | null = null;
@@ -99,6 +100,14 @@
 		unclaimedPayout = 0;
 	}
 
+	function applyClaimsResult(result: ClaimsResult) {
+		claimHistory = result.claimHistory;
+		holdings = result.holdings;
+		totalEarned = result.totals.earned;
+		totalClaimed = result.totals.claimed;
+		unclaimedPayout = result.totals.unclaimed;
+	}
+
 	onMount(() => {
 		claimSuccess = false;
 		subscribeToWallet();
@@ -116,68 +125,104 @@
 		});
 	}
 
+	async function fetchClaimsData(
+		cacheKey: string,
+		forceFresh: boolean,
+		recentClaimTxHashes?: string[],
+		incremental = false
+	): Promise<ClaimsResult | null> {
+		const result = await claimsService.loadClaimsForWallet(cacheKey, {
+			refreshContextEvents: forceFresh,
+			claimTxHashes: recentClaimTxHashes,
+			onPartialResult: incremental
+				? (partial) => {
+						if (!partial.hasCsvLoadError) {
+							applyClaimsResult(partial);
+						}
+					}
+				: undefined
+		});
+
+		dataLoadError = !!result.hasCsvLoadError;
+		if (!dataLoadError) {
+			claimsCache.set(cacheKey, result);
+			applyClaimsResult(result);
+		}
+		return result;
+	}
+
 	async function loadClaimsData(
 		addressOverride?: string,
 		forceFresh = false,
 		recentClaimTxHashes?: string[]
 	) {
+		const cacheKey = addressOverride ?? $signerAddress ?? '';
+		if (!cacheKey) {
+			pageLoading = false;
+			return;
+		}
+
+		const cached = forceFresh ? null : claimsCache.get(cacheKey);
+		const hasCachedUi = !!cached && !cached.hasCsvLoadError;
+
+		if (hasCachedUi) {
+			dataLoadError = false;
+			applyClaimsResult(cached);
+			pageLoading = false;
+			void refreshClaimsInBackground(cacheKey, forceFresh, recentClaimTxHashes);
+			return;
+		}
+
 		pageLoading = true;
 		dataLoadError = false;
+		claimsRefreshing = false;
+
 		try {
-			// Build catalog to get token metadata for expected next payout
 			if (!catalogRef) {
 				const catalog = useCatalogService();
 				await catalog.build();
 				catalogRef = catalog;
 			}
 
-			const cacheKey = addressOverride ?? $signerAddress ?? '';
-			if (!cacheKey) {
+			if (cached?.hasCsvLoadError) {
+				resetClaimsState();
 				pageLoading = false;
-				return;
-			}
-			const cached = forceFresh ? null : claimsCache.get(cacheKey);
-			if (cached) {
-				dataLoadError = !!cached.hasCsvLoadError;
-				if (dataLoadError) {
-					resetClaimsState();
-					pageLoading = false;
-					return;
-				}
-				claimHistory = cached.claimHistory;
-				holdings = cached.holdings;
-				totalEarned = cached.totals.earned;
-				totalClaimed = cached.totals.claimed;
-				unclaimedPayout = cached.totals.unclaimed;
-				pageLoading = false;
+				dataLoadError = true;
 				return;
 			}
 
-			const result = await claimsService.loadClaimsForWallet(cacheKey, {
-				refreshContextEvents: forceFresh,
-				claimTxHashes: recentClaimTxHashes
-			});
-			
-			// Store in cache
-			dataLoadError = !!result.hasCsvLoadError;
-			if (!dataLoadError) {
-				claimsCache.set(cacheKey, result);
-			}
-			
-			if (!dataLoadError) {
-				claimHistory = result.claimHistory;
-				holdings = result.holdings;
-				totalEarned = result.totals.earned;
-				totalClaimed = result.totals.claimed;
-				unclaimedPayout = result.totals.unclaimed;
-			}
-			// On partial error (hasCsvLoadError), preserve any existing data rather than wiping
+			await fetchClaimsData(cacheKey, forceFresh, recentClaimTxHashes, true);
 		} catch (error) {
 			console.error('Error loading claims:', error);
-			// Preserve existing data on error - only set error flag, don't wipe state
 			dataLoadError = true;
 		} finally {
 			pageLoading = false;
+			claimsRefreshing = false;
+		}
+	}
+
+	async function refreshClaimsInBackground(
+		cacheKey: string,
+		forceFresh: boolean,
+		recentClaimTxHashes?: string[]
+	) {
+		if (!forceFresh && !claimsCache.isStale(cacheKey)) return;
+
+		claimsRefreshing = true;
+		try {
+			if (!catalogRef) {
+				const catalog = useCatalogService();
+				await catalog.build();
+				catalogRef = catalog;
+			}
+			await fetchClaimsData(cacheKey, forceFresh, recentClaimTxHashes, true);
+		} catch (error) {
+			console.error('Error refreshing claims:', error);
+			if (holdings.length === 0 && claimHistory.length === 0) {
+				dataLoadError = true;
+			}
+		} finally {
+			claimsRefreshing = false;
 		}
 	}
 
@@ -580,6 +625,11 @@
 		</ContentSection>
 	{:else}
 		<!-- Error banner when we have existing data but refresh failed -->
+		{#if claimsRefreshing}
+			<div class="bg-light-gray border-b border-black/10 px-4 py-2">
+				<p class="max-w-6xl mx-auto text-sm text-black/70">Refreshing claims data…</p>
+			</div>
+		{/if}
 		{#if dataLoadError}
 			<div class="bg-orange-100 border-b border-orange-300 px-4 py-3">
 				<div class="max-w-6xl mx-auto flex items-center justify-between gap-4">

--- a/src/routes/(main)/portfolio/+page.svelte
+++ b/src/routes/(main)/portfolio/+page.svelte
@@ -471,26 +471,196 @@ function percentageDisplay(value: number): string {
 		downloadCsvFile(filename, csvLines.join('\n'));
 	}
 
-	async function loadAllClaimsData(): Promise<ClaimsResult | null> {
+	function mapClaimsHoldingsFromResult(claimsResult: ClaimsResult): ClaimGroupSummary[] {
+		return claimsResult.holdings.map((group: ClaimsHoldingsGroup) => {
+			const normalizedTokenAddress = group.tokenAddress?.toLowerCase();
+			const groupClaims = claimsResult.claimHistory.filter(
+				(claim) => claim.tokenAddress?.toLowerCase() === normalizedTokenAddress,
+			);
+			const claimedAmount = groupClaims.reduce((sum, claim) => {
+				const amount = Number(claim.amount ?? 0);
+				const isCompleted = !claim.status || claim.status === 'completed';
+				return sum + (isCompleted && Number.isFinite(amount) ? amount : 0);
+			}, 0);
+			const unclaimedAmountRaw = Number(group.totalAmount ?? 0);
+			const unclaimedAmount = Number.isFinite(unclaimedAmountRaw) ? unclaimedAmountRaw : 0;
+			const totalEarned = claimedAmount + unclaimedAmount;
+			return {
+				fieldName: group.fieldName,
+				tokenAddress: group.tokenAddress,
+				unclaimedAmount,
+				claimedAmount,
+				totalEarned,
+				holdings: group.holdings,
+			};
+		});
+	}
+
+	function applyClaimsSnapshot(
+		claimsResult: ClaimsResult,
+		orderHashToMonth: Record<string, string> = {},
+	) {
+		claimHistory = claimsResult.claimHistory;
+		totalPayoutsEarned = claimsResult.totals.earned;
+		unclaimedPayout = claimsResult.totals.unclaimed;
+		claimsHoldings = mapClaimsHoldingsFromResult(claimsResult);
+		latestClaimsSnapshot = claimsResult;
+		claimsDataUnavailable = false;
+
+		if (claimHistory.length > 0 && Object.keys(orderHashToMonth).length > 0) {
+			claimHistory = claimHistory.map((claim) => {
+				if (claim.orderHash) {
+					const month = orderHashToMonth[claim.orderHash.toLowerCase()];
+					if (month) {
+						return { ...claim, date: `${month}-01T00:00:00.000Z` };
+					}
+				}
+				return claim;
+			});
+		}
+	}
+
+	function payoutFieldsForSft(
+		normalizedSftAddress: string,
+	): Pick<
+		PortfolioHolding,
+		| 'totalPayoutsEarned'
+		| 'unclaimedAmount'
+		| 'claimedAmount'
+		| 'lastPayoutAmount'
+		| 'lastPayoutDate'
+		| 'claimHistory'
+		| 'capitalReturned'
+		| 'unrecoveredCapital'
+	> {
+		const sftClaimsGroup = claimsHoldings.find(
+			(group) => group.tokenAddress?.toLowerCase() === normalizedSftAddress,
+		);
+
+		let claimedAmountForSft = 0;
+		let unclaimedAmountForSft = 0;
+		let totalEarnedForSft = 0;
+
+		if (sftClaimsGroup) {
+			claimedAmountForSft = Number(sftClaimsGroup.claimedAmount ?? 0);
+			unclaimedAmountForSft = Number(sftClaimsGroup.unclaimedAmount ?? 0);
+			const groupTotal = Number(sftClaimsGroup.totalEarned ?? 0);
+			totalEarnedForSft = groupTotal || claimedAmountForSft + unclaimedAmountForSft;
+		}
+
+		const sftClaims = claimHistory.filter(
+			(claim) => claim.tokenAddress?.toLowerCase() === normalizedSftAddress,
+		);
+		const totalEarnedFromHistory = sftClaims.reduce((sum, claim) => {
+			const amount = Number(claim?.amount ?? 0);
+			return sum + (Number.isFinite(amount) ? amount : 0);
+		}, 0);
+		const claimedFromHistory = sftClaims.reduce((sum, claim) => {
+			const amount = Number(claim?.amount ?? 0);
+			const isCompleted = !claim?.status || claim.status === 'completed';
+			return sum + (isCompleted && Number.isFinite(amount) ? amount : 0);
+		}, 0);
+
+		if (!claimedAmountForSft && claimedFromHistory) {
+			claimedAmountForSft = claimedFromHistory;
+		}
+		if (!totalEarnedForSft && totalEarnedFromHistory) {
+			totalEarnedForSft = totalEarnedFromHistory;
+		}
+		if (!unclaimedAmountForSft) {
+			const pending = totalEarnedForSft - claimedAmountForSft;
+			unclaimedAmountForSft = pending > 0 ? pending : 0;
+		}
+		totalEarnedForSft = Math.max(
+			totalEarnedForSft,
+			claimedAmountForSft + unclaimedAmountForSft,
+		);
+
+		const lastClaim = sftClaims
+			.filter((claim) => !claim.status || claim.status === 'completed')
+			.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())[0];
+
+		return {
+			totalPayoutsEarned: totalEarnedForSft,
+			unclaimedAmount: unclaimedAmountForSft,
+			claimedAmount: claimedAmountForSft,
+			lastPayoutAmount: lastClaim ? Number(lastClaim.amount) : 0,
+			lastPayoutDate: lastClaim ? lastClaim.date : null,
+			claimHistory: sftClaims,
+			capitalReturned: 0,
+			unrecoveredCapital: 0,
+		};
+	}
+
+	function rebuildMonthlyPayoutsFromHistory() {
+		monthlyPayouts = [];
+		const monthlyPayoutTotals: Record<string, number> = {};
+
+		for (const claim of claimHistory) {
+			if (claim.date && claim.amount) {
+				const date = new Date(claim.date);
+				const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+				const amount = Number(claim.amount);
+				monthlyPayoutTotals[monthKey] =
+					(monthlyPayoutTotals[monthKey] ?? 0) + (Number.isFinite(amount) ? amount : 0);
+			}
+		}
+
+		for (const [monthKey, amount] of Object.entries(monthlyPayoutTotals)) {
+			monthlyPayouts.push({
+				month: monthKey,
+				amount,
+				assetName: 'Multiple Assets',
+				tokenSymbol: 'MIXED',
+				date: `${monthKey}-01`,
+				txHash: 'Multiple',
+				payoutPerToken: 0,
+			});
+		}
+
+		monthlyPayouts.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+	}
+
+	function patchHoldingsWithClaims() {
+		holdings = holdings.map((holding) => {
+			const payout = payoutFieldsForSft(holding.sftAddress.toLowerCase());
+			const capitalReturned =
+				holding.totalInvested > 0
+					? (payout.totalPayoutsEarned / holding.totalInvested) * 100
+					: 0;
+			const unrecoveredCapital = Math.max(
+				0,
+				holding.totalInvested - payout.totalPayoutsEarned,
+			);
+			return {
+				...holding,
+				...payout,
+				capitalReturned,
+				unrecoveredCapital,
+			};
+		});
+
+		rebuildMonthlyPayoutsFromHistory();
+
+		if (holdings.length > 0) {
+			totalPayoutsEarned = holdings.reduce(
+				(sum, holding) => sum + holding.totalPayoutsEarned,
+				0,
+			);
+			unclaimedPayout = holdings.reduce(
+				(sum, holding) => sum + holding.unclaimedAmount,
+				0,
+			);
+		}
+	}
+
+	async function fetchFreshClaimsData(): Promise<ClaimsResult | null> {
 		const claims = useClaimsService();
 		const address = $signerAddress || '';
-		claimsDataUnavailable = false;
 
 		if (!address) {
 			latestClaimsSnapshot = null;
 			return null;
-		}
-
-		const cached = claimsCache.get(address);
-		if (cached) {
-			logDev('Using cached claims data');
-			claimsDataUnavailable = !!cached.hasCsvLoadError;
-			if (claimsDataUnavailable) {
-				latestClaimsSnapshot = null;
-				return null;
-			}
-			latestClaimsSnapshot = cached;
-			return cached;
 		}
 
 		logDev('Loading fresh claims data');
@@ -552,45 +722,16 @@ function percentageDisplay(value: number): string {
 				field.sftTokens.map(token => token.address.toLowerCase() as Hex)
 			);
 
-			const [claimsResult, depositsResult, balancesResult] = await Promise.all([
-				loadAllClaimsData(),
+			const address = $signerAddress;
+			const cachedClaims = claimsCache.get(address);
+			const hasCachedClaims = !!cachedClaims && !cachedClaims.hasCsvLoadError;
+			let claimsResult: ClaimsResult | null = hasCachedClaims ? cachedClaims : null;
+
+			const freshClaimsPromise = fetchFreshClaimsData();
+			const [depositsResult, balancesResult] = await Promise.all([
 				sftRepository.getDepositsForOwner($signerAddress),
 				getTokenBalancesOnchain(allTokenAddresses, $signerAddress as Hex),
 			]);
-
-			// Apply claims result
-			if (claimsResult) {
-				claimHistory = claimsResult.claimHistory;
-				totalPayoutsEarned = claimsResult.totals.earned;
-				unclaimedPayout = claimsResult.totals.unclaimed;
-
-				// Map holdings to claimsHoldings format with derived totals
-				claimsHoldings = claimsResult.holdings.map((group: ClaimsHoldingsGroup) => {
-					// Filter claims by token address to ensure correct matching per token
-					const normalizedTokenAddress = group.tokenAddress?.toLowerCase();
-					const groupClaims = claimsResult.claimHistory.filter(
-						(claim) => claim.tokenAddress?.toLowerCase() === normalizedTokenAddress,
-					);
-					const claimedAmount = groupClaims.reduce((sum, claim) => {
-						const amount = Number(claim.amount ?? 0);
-						const isCompleted = !claim.status || claim.status === 'completed';
-						return sum + (isCompleted && Number.isFinite(amount) ? amount : 0);
-					}, 0);
-					const unclaimedAmountRaw = Number(group.totalAmount ?? 0);
-					const unclaimedAmount = Number.isFinite(unclaimedAmountRaw)
-						? unclaimedAmountRaw
-						: 0;
-					const totalEarned = claimedAmount + unclaimedAmount;
-					return {
-						fieldName: group.fieldName,
-						tokenAddress: group.tokenAddress,
-						unclaimedAmount,
-						claimedAmount,
-						totalEarned,
-						holdings: group.holdings,
-					};
-				});
-			}
 
 			// Load secondary purchases from localStorage
 			secondaryPurchases = loadSecondaryPurchases();
@@ -634,18 +775,8 @@ function percentageDisplay(value: number): string {
 				}
 			}
 
-			// Update claim history dates using the orderHash -> month lookup
-			if (claimHistory.length > 0 && Object.keys(orderHashToMonth).length > 0) {
-				claimHistory = claimHistory.map((claim) => {
-					if (claim.orderHash) {
-						const month = orderHashToMonth[claim.orderHash.toLowerCase()];
-						if (month) {
-							// Convert month (YYYY-MM) to ISO date (first of month)
-							return { ...claim, date: `${month}-01T00:00:00.000Z` };
-						}
-					}
-					return claim;
-				});
+			if (claimsResult) {
+				applyClaimsSnapshot(claimsResult, orderHashToMonth);
 			}
 
 			// Deduplicate SFTs by ID
@@ -937,34 +1068,7 @@ function percentageDisplay(value: number): string {
 			console.log('[Portfolio DEBUG] Final holdings count:', holdings.length);
 			console.log('[Portfolio DEBUG] Final holdings:', holdings.map(h => ({ id: h.id, name: h.name, tokens: h.tokensOwned })));
 
-			// Populate monthlyPayouts from claim history
-			monthlyPayouts = [];
-			const monthlyPayoutTotals: Record<string, number> = {};
-
-			// Process claim history to get monthly aggregations (all payouts - claimed + unclaimed)
-			// This shows when payouts were made available, not when they were claimed
-			for (const claim of claimHistory) {
-				if (claim.date && claim.amount) {
-					const date = new Date(claim.date);
-					const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-					const amount = Number(claim.amount);
-					monthlyPayoutTotals[monthKey] = (monthlyPayoutTotals[monthKey] ?? 0) + (Number.isFinite(amount) ? amount : 0);
-				}
-			}
-
-			for (const [monthKey, amount] of Object.entries(monthlyPayoutTotals)) {
-				monthlyPayouts.push({
-					month: monthKey,
-					amount: amount,
-					assetName: 'Multiple Assets',
-					tokenSymbol: 'MIXED',
-					date: `${monthKey}-01`,
-					txHash: 'Multiple',
-					payoutPerToken: 0
-				});
-			}
-
-			monthlyPayouts.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+			rebuildMonthlyPayoutsFromHistory();
 
 			// Populate tokenAllocations from holdings
 			const totalPortfolioValue = holdings.reduce(
@@ -999,6 +1103,12 @@ function percentageDisplay(value: number): string {
 			}
 
 			activeAssetsCount = holdings.length;
+
+			void freshClaimsPromise.then((freshClaims) => {
+				if (!freshClaims || freshClaims.hasCsvLoadError) return;
+				applyClaimsSnapshot(freshClaims, orderHashToMonth);
+				patchHoldingsWithClaims();
+			});
 
 		} catch (error) {
 			console.error('[Portfolio] Error loading data:', error);


### PR DESCRIPTION
## Summary

- Adds `sessionStorage`-backed claims cache (30 min TTL) so repeat visits and Claims → Portfolio navigation are near-instant
- Claims page uses stale-while-revalidate: show cached data immediately, refresh in background with a subtle banner
- `ClaimsService` streams partial results via `onPartialResult`, processes newest orders first, and increases CSV batch concurrency (8 parallel / 50ms delay)
- Portfolio no longer blocks on claims: deposits + on-chain balances render first; payout fields patch in when claims finish

Closes #175

Stacked on #172 (`feat/v6-claims-dual-era`) — merge #172 first, then this PR.

## Test plan

- [ ] Connect wallet with claimable holdings on Claims page — cached visit should render immediately; background refresh banner appears when stale
- [ ] First visit (clear sessionStorage) — Claims page should populate incrementally as batches complete
- [ ] Navigate Claims → Portfolio — Portfolio should show holdings quickly; earned/unclaimed amounts fill in when claims load
- [ ] Force refresh on Claims (`Retry`) — still loads fresh data and updates cache
- [ ] Claim All / per-asset batching from #172 still works (2 entries in `takeOrders3` for dual holdings)


Made with [Cursor](https://cursor.com)