### PR TITLE
Fix payout derivation, payout charts, and dust-supply sold-out state

### DIFF
--- a/src/lib/components/patterns/ReturnsEstimatorModal.svelte
+++ b/src/lib/components/patterns/ReturnsEstimatorModal.svelte
@@ -2,6 +2,7 @@
 	import { fade } from 'svelte/transition';
 	import { onDestroy } from 'svelte';
 	import type { TokenMetadata } from '$lib/types/MetaboardTypes';
+	import { isEffectivelySoldOut } from '$lib/utils/supplyThresholds';
 	import {
 		calculateMonthlyTokenCashflows,
 		calculateNPV,
@@ -56,21 +57,24 @@
 	let discountRate = 10;
 	let numberOfTokens = 1;
 
+	// Rounding dust counts as sold out: ALB-WR1-R2 has 2,000 wei left against a
+	// 36,000 cap, which `availableSupply > 0` treated as purchasable.
+	$: soldOut = isEffectivelySoldOut(availableSupply);
+
 	// Reset assumptions and calculate when modal opens
 	$: if (isOpen && token) {
 		oilPrice = 65;
 		discountRate = 10;
-		// Default to 1 token, unless available supply is between 0 and 1 (fractional)
-		// When sold out (availableSupply <= 0), use 1 for illustrative purposes
-		numberOfTokens = availableSupply > 0 && availableSupply < 1 ? parseFloat(availableSupply.toFixed(3)) : 1;
+		// Default to 1 token, unless available supply is a genuine fraction
+		numberOfTokens = !soldOut && availableSupply < 1 ? parseFloat(availableSupply.toFixed(3)) : 1;
 		// Explicitly trigger calculation after reset
 		updateCalculations();
 	}
 
 	// Validation error for numberOfTokens
 	// Use a small epsilon to handle floating point precision issues
-	// Don't show error when sold out (availableSupply <= 0) since calculator is for illustration only
-	$: tokensError = availableSupply > 0 && (numberOfTokens - availableSupply) > 0.0001 ? `Only ${availableSupply.toFixed(3)} tokens available` : '';
+	// No error when sold out — the calculator is illustrative only
+	$: tokensError = !soldOut && (numberOfTokens - availableSupply) > 0.0001 ? `Only ${availableSupply.toFixed(3)} tokens available` : '';
 
 	// Token Mode Calculated values - Remaining (from current month)
 	let monthlyTokenCashflows: Array<{ month: string; cashflow: number }> = [];
@@ -119,33 +123,36 @@
 	};
 
 	// Reactive metrics arrays - these re-run when values change, maintaining Svelte reactivity
+	// When the token is sold out there is nothing to mint today, so a
+	// forward-looking return is undefined rather than negative. Showing the raw
+	// numbers (a -44.76% IRR on ~zero available supply) reads as a real loss.
 	$: remainingMetrics = [
 		{
 			key: 'irr',
 			label: 'Annualized IRR',
 			value: remainingIRR,
-			formatted: `${isFinite(remainingIRR) ? remainingIRR.toFixed(2) : '—'}%`,
+			formatted: soldOut ? 'N/A' : `${isFinite(remainingIRR) ? remainingIRR.toFixed(2) : '—'}%`,
 			tooltip: tooltips.irr
 		},
 		{
 			key: 'npv',
 			label: `NPV @ ${discountRate}%`,
 			value: remainingNPV,
-			formatted: `${isFinite(remainingNPV) ? `$${remainingNPV.toFixed(2)}` : '—'}`,
+			formatted: soldOut ? 'N/A' : `${isFinite(remainingNPV) ? `$${remainingNPV.toFixed(2)}` : '—'}`,
 			tooltip: tooltips.npv
 		},
 		{
 			key: 'payback',
 			label: 'Payback Period',
 			value: remainingPayback,
-			formatted: `${isFinite(remainingPayback) ? remainingPayback.toFixed(1) : '—'} mo`,
+			formatted: soldOut ? 'N/A' : `${isFinite(remainingPayback) ? remainingPayback.toFixed(1) : '—'} mo`,
 			tooltip: tooltips.payback
 		},
 		{
 			key: 'apr',
 			label: 'APR',
 			value: remainingAPR,
-			formatted: `${isFinite(remainingAPR) ? remainingAPR.toFixed(2) : '—'}%`,
+			formatted: soldOut ? 'N/A' : `${isFinite(remainingAPR) ? remainingAPR.toFixed(2) : '—'}%`,
 			tooltip: tooltips.apr
 		}
 	];
@@ -481,10 +488,10 @@
 					</div>
 
 					<!-- Sold Out Notice -->
-					{#if availableSupply <= 0}
+					{#if soldOut}
 						<div class="flex justify-center">
 							<div class="bg-gray-100 border border-gray-300 rounded-none px-4 py-2 inline-flex items-center gap-2 text-sm">
-								<span class="text-gray-600 font-medium">Sold out. Numbers shown for illustrative purposes.</span>
+								<span class="text-gray-600 font-medium">This token is sold out — there are none left to mint, so returns from today are not applicable. Figures below are illustrative only.</span>
 							</div>
 						</div>
 					{/if}
@@ -508,13 +515,15 @@
 					<div class={sectionClasses}>
 						<div class="flex items-center justify-between mb-4">
 							<h3 class={sectionTitleClasses}>Return Metrics</h3>
-							<button
-								type="button"
-								on:click={setFullyDilutedReturns}
-								class="px-3 py-1.5 bg-secondary text-white text-xs font-medium rounded-none hover:bg-opacity-90 transition-colors"
-							>
-								View Fully Diluted Returns
-							</button>
+							{#if !soldOut}
+								<button
+									type="button"
+									on:click={setFullyDilutedReturns}
+									class="px-3 py-1.5 bg-secondary text-white text-xs font-medium rounded-none hover:bg-opacity-90 transition-colors"
+								>
+									View Fully Diluted Returns
+								</button>
+							{/if}
 						</div>
 
 						{#each [{title: 'Remaining (From Today)', metrics: remainingMetrics, suffix: 'remaining'}, {title: 'Lifetime (From Start)', metrics: lifetimeMetrics, suffix: 'lifetime'}] as section (section.suffix)}

--- a/src/lib/components/patterns/assets/AssetCard.svelte
+++ b/src/lib/components/patterns/assets/AssetCard.svelte
@@ -10,8 +10,9 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 	import FormattedReturn from '$lib/components/components/FormattedReturn.svelte';
 	import { getEnergyFieldId } from '$lib/utils/energyFieldGrouping';
 	import { hasAvailableSupplySync } from '$lib/utils/supplyHelpers';
-	import { calculateLifetimeIRR, calculateMonthlyTokenCashflows, calculateIRR } from '$lib/utils/returnsEstimatorHelpers';
-	import { formatSupplyDisplay } from '$lib/utils/supplyHelpers';
+	import { calculateLifetimeIRR, calculateMonthlyTokenCashflows, calculateIRR, calculateFullyDilutedReturns } from '$lib/utils/returnsEstimatorHelpers';
+	import { formatSupplyDisplay, isEffectivelySoldOut } from '$lib/utils/supplyHelpers';
+	import { sumRemainingProduction } from '$lib/utils/productionHelpers';
 	import ReturnsEstimatorModal from '$lib/components/patterns/ReturnsEstimatorModal.svelte';
 
 	export let asset: Asset;
@@ -67,6 +68,9 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 	
 	// Use asset data directly from the data store
 	$: latestReport = asset.monthlyReports[asset.monthlyReports.length - 1] || null;
+	// Only production still ahead of us — the projections array covers the
+	// asset's whole life, roughly half of which is already produced and paid.
+	$: remainingBoe = sumRemainingProduction(asset.plannedProduction?.projections);
 
 	// Use tokens array directly
 	$: tokensArray = token;
@@ -143,7 +147,7 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 		<!-- Key Stats -->
 		<div class={highlightedStatsClasses}>
 			<div class={highlightStatClasses}>
-				<span class={highlightValueClasses}>{asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0) ? formatSmartNumber(asset.plannedProduction.projections.reduce((acc, curr) => acc + curr.production, 0), { suffix: ' boe' }) : 'TBD'}</span>
+				<span class={highlightValueClasses}>{remainingBoe ? formatSmartNumber(remainingBoe, { suffix: ' boe' }) : 'TBD'}</span>
 				<span class={highlightLabelClasses}>Exp. Remaining</span>
 			</div>
 			<div class={highlightStatClasses}>
@@ -197,19 +201,26 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 				{@const remainingCashflows = calculateMonthlyTokenCashflows(tokenItem, 65, mintedSupply, 1).map(m => m.cashflow)}
 				{@const monthlyIRR = remainingCashflows.length > 1 ? calculateIRR(remainingCashflows) : 0}
 				{@const currentReturns = monthlyIRR > -0.99 ? (Math.pow(1 + monthlyIRR, 12) - 1) * 100 : -99}
-				{@const fullyDilutedReturns = calculateLifetimeIRR(tokenItem, 65, maxSupply, 1)}
+				{@const availableSupply = maxSupply - mintedSupply}
+				{@const soldOut = isEffectivelySoldOut(availableSupply)}
+				<!-- Lifetime is informational only: it includes months already paid out to
+				     earlier holders, so it is not what a buyer today would earn. -->
+				{@const lifetimeReturns = calculateLifetimeIRR(tokenItem, 65, mintedSupply, 1)}
+				{@const fullyDilutedReturns = soldOut ? 0 : calculateFullyDilutedReturns(tokenItem, 65, mintedSupply, availableSupply)}
 					<div class={tokenButtonClasses}>
 						<!-- Desktop: Full token info -->
 						<div class="hidden sm:flex w-full justify-between items-start gap-4">
 							<div class={tokenButtonLeftClasses}>
 								<span class={tokenSymbolClasses}>{tokenItem.symbol}</span>
 								<span class={tokenNameClasses}>{tokenItem.releaseName}</span>
-								<button
-									class="mt-2 px-3 py-1.5 bg-black text-white text-xs font-bold rounded-none hover:bg-primary hover:scale-105 transition-all duration-200 w-1/2"
-									on:click|stopPropagation={() => handleBuyTokens(tokenItem.contractAddress)}
-								>
-									Buy
-								</button>
+								{#if !soldOut}
+									<button
+										class="mt-2 px-3 py-1.5 bg-black text-white text-xs font-bold rounded-none hover:bg-primary hover:scale-105 transition-all duration-200 w-1/2"
+										on:click|stopPropagation={() => handleBuyTokens(tokenItem.contractAddress)}
+									>
+										Buy
+									</button>
+								{/if}
 							</div>
 							<div class="flex flex-col items-start gap-2 border-l border-gray-300 pl-2">
 								<div class="text-sm font-bold text-black text-left mb-1">Returns</div>
@@ -220,10 +231,22 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 											<FormattedReturn value={currentReturns} />
 										</span>
 									</div>
-									<div class="flex items-center gap-1.5">
-										<span class="text-xs text-gray-500 font-medium">Fully Diluted:</span>
-										<span class="text-base text-primary font-extrabold">
-											<FormattedReturn value={fullyDilutedReturns} />
+									{#if soldOut}
+										<div class="flex items-center gap-1.5">
+											<span class="text-xs font-bold text-black uppercase tracking-wider">Sold Out</span>
+										</div>
+									{:else}
+										<div class="flex items-center gap-1.5">
+											<span class="text-xs text-gray-500 font-medium">Fully Diluted:</span>
+											<span class="text-base text-primary font-extrabold">
+												<FormattedReturn value={fullyDilutedReturns} />
+											</span>
+										</div>
+									{/if}
+									<div class="flex items-center gap-1.5" title="Return since launch, including payouts already made to earlier holders. Informational only — not a forward-looking return.">
+										<span class="text-xs text-gray-500 font-medium">Lifetime:</span>
+										<span class="text-base text-gray-500 font-extrabold">
+											<FormattedReturn value={lifetimeReturns} />
 										</span>
 									</div>
 								</div>
@@ -252,10 +275,22 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 												<FormattedReturn value={currentReturns} />
 											</span>
 										</div>
+										{#if soldOut}
+											<div class="flex items-center gap-1">
+												<span class="font-bold text-black uppercase tracking-wider">Sold Out</span>
+											</div>
+										{:else}
+											<div class="flex items-center gap-1">
+												<span class="text-gray-500">Diluted:</span>
+												<span class="text-primary font-extrabold">
+													<FormattedReturn value={fullyDilutedReturns} />
+												</span>
+											</div>
+										{/if}
 										<div class="flex items-center gap-1">
-											<span class="text-gray-500">Diluted:</span>
-											<span class="text-primary font-extrabold">
-												<FormattedReturn value={fullyDilutedReturns} />
+											<span class="text-gray-500">Lifetime:</span>
+											<span class="text-gray-500 font-extrabold">
+												<FormattedReturn value={lifetimeReturns} />
 											</span>
 										</div>
 									</div>

--- a/src/lib/components/patterns/assets/AssetDetailHeader.svelte
+++ b/src/lib/components/patterns/assets/AssetDetailHeader.svelte
@@ -210,10 +210,13 @@ export let onLocationClick: (() => void) | undefined = undefined;
 				})()}
 				size="small"
 			/>
+			<!-- This is the count of token releases, not how many are still on
+			     sale — labelling it "Available" contradicted the "Currently Sold
+			     Out" banners on the releases themselves. -->
 			<StatsCard
-				title="Available Tokens"
+				title="Token Releases"
 				value={tokenCount.toString()}
-				subtitle="Token releases"
+				subtitle="Total issued"
 				size="small"
 				on:click={onTokenSectionClick || (() => {})}
 			/>

--- a/src/lib/components/patterns/carousel/FeaturedTokenCarousel.svelte
+++ b/src/lib/components/patterns/carousel/FeaturedTokenCarousel.svelte
@@ -6,6 +6,7 @@
 	import { sftMetadata, sfts } from '$lib/stores';
 	import { chainId } from 'svelte-wagmi';
 	import { formatSmartNumber } from '$lib/utils/formatters';
+	import { sumRemainingProduction } from '$lib/utils/productionHelpers';
 	import { formatSupplyDisplay } from '$lib/utils/supplyHelpers';
 	import type { TokenMetadata } from '$lib/types/MetaboardTypes';
 	import { getEnergyFieldId } from '$lib/utils/energyFieldGrouping';
@@ -466,7 +467,7 @@
 					<div class={assetStatsClasses}>
 						<div class={statItemClasses}>
 							<div class={statLabelClasses}>Remaining Production</div>
-							<div class={statValueClasses}>{item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0) ? formatSmartNumber(item.asset.plannedProduction.projections.reduce((acc, curr) => acc + curr.production, 0), { suffix: ' boe' }) : 'TBD'}</div>
+							<div class={statValueClasses}>{sumRemainingProduction(item.asset.plannedProduction?.projections) ? formatSmartNumber(sumRemainingProduction(item.asset.plannedProduction?.projections), { suffix: ' boe' }) : 'TBD'}</div>
 						</div>
 					</div>
 
@@ -483,7 +484,7 @@
 					<h3 class={assetNameClasses}>{item.asset.name}</h3>
 					<div class="text-sm text-black opacity-70">
 						<span class="font-medium">Remaining Production:</span> 
-						<span>{item.asset.plannedProduction?.projections.reduce((acc, curr) => acc + curr.production, 0) ? formatSmartNumber(item.asset.plannedProduction.projections.reduce((acc, curr) => acc + curr.production, 0), { suffix: ' boe' }) : 'TBD'}</span>
+						<span>{sumRemainingProduction(item.asset.plannedProduction?.projections) ? formatSmartNumber(sumRemainingProduction(item.asset.plannedProduction?.projections), { suffix: ' boe' }) : 'TBD'}</span>
 					</div>
 				</div>
 							</div>

--- a/src/lib/data/transformers/sftTransformers.ts
+++ b/src/lib/data/transformers/sftTransformers.ts
@@ -6,6 +6,7 @@
 import type { OffchainAssetReceiptVault } from "$lib/types/graphql";
 import type { Asset, Token, PlannedProduction } from "$lib/types/uiTypes";
 import { mergeProductionHistory } from "$lib/utils/productionMerge";
+import { resolvePayoutPerToken } from "$lib/utils/payoutHelpers";
 import {
   TokenType,
   ProductionStatus,
@@ -141,7 +142,8 @@ function toIsoDate(value: unknown): ISODateTimeString {
 }
 
 function normalizePayoutData(
-  entries?: PinnedMetadataPayoutEntry[],
+  entries: PinnedMetadataPayoutEntry[] | undefined,
+  mintedSupply: bigint | string | number | undefined,
 ): PayoutData[] {
   if (!Array.isArray(entries)) {
     return [];
@@ -150,11 +152,19 @@ function normalizePayoutData(
   for (const entry of entries) {
     const month = ensureYearMonth(entry?.month);
     const payout = entry?.tokenPayout ?? {};
+    const totalPayout = toNumber(payout.totalPayout);
     result.push({
       month,
       tokenPayout: {
-        totalPayout: toNumber(payout.totalPayout),
-        payoutPerToken: toNumber(payout.payoutPerToken),
+        totalPayout,
+        // `payoutPerToken` is a removed schema field — trust it where legacy
+        // entries still carry it, otherwise derive from totalPayout and the
+        // fixed supply. See resolvePayoutPerToken.
+        payoutPerToken: resolvePayoutPerToken(
+          toNumber(payout.payoutPerToken),
+          totalPayout,
+          mintedSupply,
+        ),
         txHash: toString(payout.txHash),
         orderHash: toString(payout.orderHash),
       },
@@ -164,9 +174,10 @@ function normalizePayoutData(
 }
 
 function toMergePayoutRecords(
-  entries?: PinnedMetadataPayoutEntry[],
+  entries: PinnedMetadataPayoutEntry[] | undefined,
+  mintedSupply: bigint | string | number | undefined,
 ): MergePayoutRecord[] {
-  return normalizePayoutData(entries).map((entry) => ({
+  return normalizePayoutData(entries, mintedSupply).map((entry) => ({
     month: entry.month,
     tokenPayout: { payoutPerToken: entry.tokenPayout.payoutPerToken },
   }));
@@ -497,7 +508,10 @@ export class TokenMetadataTransformer extends BaseSftTransformer {
       tokenType: ensureTokenType(pinnedMetadata.tokenType),
       firstPaymentDate: ensureYearMonth(pinnedMetadata.firstPaymentDate),
       sharePercentage: pinnedMetadata.sharePercentage,
-      payoutData: normalizePayoutData(pinnedMetadata.payoutData),
+      payoutData: normalizePayoutData(
+        pinnedMetadata.payoutData,
+        sft.totalShares,
+      ),
       asset: buildTokenAssetData(assetMetadata),
       metadata: ensureMetadata(pinnedMetadata.metadata, baseMetadata),
     };
@@ -533,6 +547,7 @@ export class AssetTransformer extends BaseSftTransformer {
     const monthlyReports = this.transformMonthlyReports(
       assetData,
       pinnedMetadata,
+      sft.totalShares,
     );
 
     const assetStatus = ensureAssetStatus(assetData.production?.status);
@@ -687,6 +702,7 @@ export class AssetTransformer extends BaseSftTransformer {
   private transformMonthlyReports(
     assetData: PinnedMetadataAsset,
     pinnedMetadata: PinnedMetadata,
+    mintedSupply: bigint | string | number | undefined,
   ) {
     const historical: MergeHistoricalRecord[] = Array.isArray(
       assetData.historicalProduction,
@@ -719,7 +735,10 @@ export class AssetTransformer extends BaseSftTransformer {
         }))
       : [];
 
-    const payoutRecords = toMergePayoutRecords(pinnedMetadata?.payoutData);
+    const payoutRecords = toMergePayoutRecords(
+      pinnedMetadata?.payoutData,
+      mintedSupply,
+    );
 
     return mergeProductionHistory(historical, receipts, payoutRecords);
   }

--- a/src/lib/utils/payoutHelpers.spec.ts
+++ b/src/lib/utils/payoutHelpers.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  derivePayoutPerToken,
+  resolvePayoutPerToken,
+  toTokenCount,
+} from "./payoutHelpers";
+
+// ALB-WR1-R1 is fully minted at exactly 12,000 tokens, so the historical
+// `payoutPerToken` values that used to be pinned in the metadata are an exact
+// oracle for the derivation. Figures below are real production data.
+const R1_SUPPLY_WEI = "12000000000000000000000"; // 12,000 * 1e18
+
+describe("toTokenCount", () => {
+  it("converts an 18-decimal wei string to a token count", () => {
+    expect(toTokenCount(R1_SUPPLY_WEI)).toBe(12000);
+  });
+
+  it("converts a bigint", () => {
+    expect(toTokenCount(12000n * 10n ** 18n)).toBe(12000);
+  });
+
+  it("passes a plain token count through", () => {
+    expect(toTokenCount(12000)).toBe(12000);
+  });
+
+  it("returns 0 for missing or unparseable supply", () => {
+    expect(toTokenCount(undefined)).toBe(0);
+    expect(toTokenCount(null)).toBe(0);
+    expect(toTokenCount("not-a-number")).toBe(0);
+  });
+});
+
+describe("derivePayoutPerToken", () => {
+  it.each([
+    ["2025-09", 590.39, 0.0492],
+    ["2025-10", 828.625, 0.06905],
+    ["2025-11", 648.65, 0.054054],
+    ["2025-12", 668.025, 0.055669],
+    ["2026-01", 737.625, 0.061469],
+  ])(
+    "reproduces the pinned ALB-WR1-R1 payoutPerToken for %s",
+    (_month, totalPayout, expected) => {
+      // The pinned values were themselves rounded to ~5 decimal places, so
+      // match to that precision rather than to the full quotient.
+      expect(derivePayoutPerToken(totalPayout, R1_SUPPLY_WEI)).toBeCloseTo(
+        expected as number,
+        5,
+      );
+    },
+  );
+
+  it("derives a value for months where payoutPerToken was dropped from the schema", () => {
+    // 2026-06, the month added by PR #180. Metadata carries payoutPerToken: 0.
+    expect(derivePayoutPerToken(857.925, R1_SUPPLY_WEI)).toBeCloseTo(
+      0.07149375,
+      8,
+    );
+  });
+
+  it("returns 0 when supply is unknown rather than dividing by zero", () => {
+    expect(derivePayoutPerToken(857.925, undefined)).toBe(0);
+    expect(derivePayoutPerToken(857.925, "0")).toBe(0);
+    expect(Number.isFinite(derivePayoutPerToken(857.925, "0"))).toBe(true);
+  });
+
+  it("returns 0 for a zero or non-finite payout", () => {
+    expect(derivePayoutPerToken(0, R1_SUPPLY_WEI)).toBe(0);
+    expect(derivePayoutPerToken(Number.NaN, R1_SUPPLY_WEI)).toBe(0);
+  });
+});
+
+describe("resolvePayoutPerToken", () => {
+  // ALB-WR1-R2 is still selling: cap 36,000, ~21,617 minted when 2025-11 was
+  // pinned. Deriving from today's supply would report $0.0664 for a month that
+  // actually paid $0.1106 — so a legacy pinned value must win.
+  const R2_SUPPLY_NOW_WEI = "36000000000000000000000";
+
+  it("keeps a legacy pinned value rather than rewriting it with today's supply", () => {
+    expect(resolvePayoutPerToken(0.1106, 2390.854, R2_SUPPLY_NOW_WEI)).toBe(
+      0.1106,
+    );
+  });
+
+  it("derives when the pinned field is 0 (schema-removed months)", () => {
+    // ALB-WR1-R2 2026-06, pinned as payoutPerToken: 0.
+    expect(
+      resolvePayoutPerToken(0, 3018.679, R2_SUPPLY_NOW_WEI),
+    ).toBeCloseTo(0.08385219, 8);
+  });
+
+  it("derives when the pinned field is missing entirely", () => {
+    expect(
+      resolvePayoutPerToken(undefined, 3018.679, R2_SUPPLY_NOW_WEI),
+    ).toBeCloseTo(0.08385219, 8);
+  });
+
+  it("ignores a negative or non-finite pinned value", () => {
+    expect(resolvePayoutPerToken(-1, 3018.679, R2_SUPPLY_NOW_WEI)).toBeCloseTo(
+      0.08385219,
+      8,
+    );
+    expect(
+      resolvePayoutPerToken(Number.NaN, 3018.679, R2_SUPPLY_NOW_WEI),
+    ).toBeCloseTo(0.08385219, 8);
+  });
+});

--- a/src/lib/utils/payoutHelpers.ts
+++ b/src/lib/utils/payoutHelpers.ts
@@ -1,0 +1,93 @@
+import { formatEther } from "viem";
+
+/**
+ * `payoutPerToken` was removed from the pinned-metadata schema.
+ *
+ * Entries pinned from 2026-02 onward carry `payoutPerToken: 0`, and the values
+ * it held for partially-sold tokens were computed against whatever supply
+ * existed at pin time — so they were never comparable across months. Token
+ * supply is fixed, so the per-token figure is derived from `totalPayout`
+ * instead of being read off the metadata.
+ *
+ * @param totalPayout   Total USD distributed for the month.
+ * @param mintedSupply  Token supply as an 18-decimal wei value (the SFT's
+ *                      `totalShares`), or a plain token count.
+ * @returns USD per token, or 0 when the supply is unknown/zero.
+ */
+export function derivePayoutPerToken(
+  totalPayout: number,
+  mintedSupply: bigint | string | number | undefined | null,
+): number {
+  if (!Number.isFinite(totalPayout) || totalPayout === 0) {
+    return 0;
+  }
+
+  const supply = toTokenCount(mintedSupply);
+  if (!Number.isFinite(supply) || supply <= 0) {
+    return 0;
+  }
+
+  return totalPayout / supply;
+}
+
+/**
+ * Resolve the per-token payout for a month, preferring a pinned value.
+ *
+ * Entries pinned before the schema change still carry a `payoutPerToken` that
+ * was computed against the supply in force at pin time. For a token that is
+ * still selling (e.g. ALB-WR1-R2, cap 36,000 and rising) that legacy value is
+ * closer to what holders actually received than anything we can recompute
+ * today, because deriving from the *current* supply retroactively shrinks every
+ * historical month and keeps drifting down as more tokens mint.
+ *
+ * So: trust a non-zero pinned value, and only derive when the field is absent
+ * or zero — which is every month pinned from 2026-02 onward.
+ *
+ * KNOWN LIMITATION: derived months on a partially-sold token are still divided
+ * by current supply, so they understate what early holders received. Consumers
+ * that have the wallet's real claimed amount (matched by orderHash) should
+ * prefer that over this estimate.
+ */
+export function resolvePayoutPerToken(
+  pinnedPayoutPerToken: number | undefined | null,
+  totalPayout: number,
+  mintedSupply: bigint | string | number | undefined | null,
+): number {
+  if (
+    typeof pinnedPayoutPerToken === "number" &&
+    Number.isFinite(pinnedPayoutPerToken) &&
+    pinnedPayoutPerToken > 0
+  ) {
+    return pinnedPayoutPerToken;
+  }
+  return derivePayoutPerToken(totalPayout, mintedSupply);
+}
+
+/**
+ * Normalise a supply value to a whole-token count.
+ *
+ * Accepts the wei-denominated `totalShares` string the subgraph returns, a
+ * bigint, or an already-converted token count.
+ */
+export function toTokenCount(
+  mintedSupply: bigint | string | number | undefined | null,
+): number {
+  if (mintedSupply === undefined || mintedSupply === null) {
+    return 0;
+  }
+
+  if (typeof mintedSupply === "number") {
+    return Number.isFinite(mintedSupply) ? mintedSupply : 0;
+  }
+
+  try {
+    // Strings from the subgraph are wei; anything non-integer is already a
+    // token count and would throw in BigInt(), so fall through to Number().
+    const asBigInt =
+      typeof mintedSupply === "bigint" ? mintedSupply : BigInt(mintedSupply);
+    return Number(formatEther(asBigInt));
+  } catch {
+    const parsed = Number(mintedSupply);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+}

--- a/src/lib/utils/productionHelpers.spec.ts
+++ b/src/lib/utils/productionHelpers.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  currentYearMonth,
+  sumRemainingProduction,
+} from "./productionHelpers";
+import { isEffectivelySoldOut } from "./supplyThresholds";
+
+// Shape of the live Wressle-1 plannedProduction.projections: whole-life,
+// 2025-05 → 2027-12. Abridged, with real values at the boundaries.
+const PROJECTIONS = [
+  { month: "2025-05", production: 100 },
+  { month: "2025-06", production: 200 },
+  { month: "2026-07", production: 300 },
+  { month: "2026-08", production: 400 },
+  { month: "2026-09", production: 500 },
+  { month: "2027-12", production: 600 },
+];
+
+describe("currentYearMonth", () => {
+  it("formats as YYYY-MM", () => {
+    expect(currentYearMonth(new Date("2026-08-03T12:00:00Z"))).toBe("2026-08");
+  });
+
+  it("zero-pads single-digit months", () => {
+    expect(currentYearMonth(new Date("2026-01-31T23:59:59Z"))).toBe("2026-01");
+  });
+});
+
+describe("sumRemainingProduction", () => {
+  it("excludes months already produced", () => {
+    // From 2026-08: 400 + 500 + 600. The 100/200/300 are already produced.
+    expect(sumRemainingProduction(PROJECTIONS, "2026-08")).toBe(1500);
+  });
+
+  it("includes the current month", () => {
+    expect(sumRemainingProduction(PROJECTIONS, "2026-07")).toBe(1800);
+  });
+
+  it("differs sharply from the whole-life total it replaces", () => {
+    const wholeLife = PROJECTIONS.reduce((a, p) => a + p.production, 0);
+    expect(wholeLife).toBe(2100);
+    expect(sumRemainingProduction(PROJECTIONS, "2026-08")).toBeLessThan(
+      wholeLife,
+    );
+  });
+
+  it("returns 0 once the asset is past its final projection", () => {
+    expect(sumRemainingProduction(PROJECTIONS, "2028-01")).toBe(0);
+  });
+
+  it("returns 0 for missing or malformed input", () => {
+    expect(sumRemainingProduction(undefined, "2026-08")).toBe(0);
+    expect(sumRemainingProduction([], "2026-08")).toBe(0);
+    expect(
+      sumRemainingProduction(
+        [{ month: undefined, production: 999 }],
+        "2026-08",
+      ),
+    ).toBe(0);
+  });
+
+  it("skips entries with non-numeric production", () => {
+    expect(
+      sumRemainingProduction(
+        [
+          { month: "2026-09", production: Number.NaN },
+          { month: "2026-10", production: 50 },
+        ],
+        "2026-08",
+      ),
+    ).toBe(50);
+  });
+});
+
+// isEffectivelySoldOut is validated here against the real on-chain numbers,
+// since it is the other half of the "dust" fix.
+describe("isEffectivelySoldOut (real on-chain supply)", () => {
+  it("treats ALB-WR1-R2's 2,000 wei of leftover supply as sold out", () => {
+    // maxSupply 36,000 - minted 35,999.999999999999998
+    expect(isEffectivelySoldOut(36000 - 35999.999999999999998)).toBe(true);
+  });
+
+  it("treats a fully minted token as sold out", () => {
+    expect(isEffectivelySoldOut(0)).toBe(true);
+  });
+
+  it("treats a genuinely available token as not sold out", () => {
+    expect(isEffectivelySoldOut(5000)).toBe(false);
+    expect(isEffectivelySoldOut(1)).toBe(false);
+  });
+
+  it("treats sub-token remainders as sold out", () => {
+    expect(isEffectivelySoldOut(0.5)).toBe(true);
+  });
+
+  it("does not claim sold out when availability is unknown", () => {
+    expect(isEffectivelySoldOut(undefined)).toBe(false);
+    expect(isEffectivelySoldOut(null)).toBe(false);
+  });
+});

--- a/src/lib/utils/productionHelpers.ts
+++ b/src/lib/utils/productionHelpers.ts
@@ -1,0 +1,40 @@
+export type ProductionProjection = {
+  month?: string;
+  production?: number;
+};
+
+/**
+ * Current month as `YYYY-MM`.
+ */
+export function currentYearMonth(now: Date = new Date()): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+/**
+ * Sum only the production still ahead of us.
+ *
+ * `plannedProduction.projections` covers the asset's whole life, starting well
+ * before today — for Wressle-1 it runs 2025-05 → 2027-12, of which roughly half
+ * has already been produced and distributed. Summing the lot and labelling it
+ * "Exp. Remaining" overstates what a buyer is actually buying into by ~2x.
+ *
+ * @param projections Whole-life monthly projections.
+ * @param fromMonth   Inclusive `YYYY-MM` lower bound; defaults to this month.
+ */
+export function sumRemainingProduction(
+  projections: ProductionProjection[] | undefined,
+  fromMonth: string = currentYearMonth(),
+): number {
+  if (!Array.isArray(projections)) {
+    return 0;
+  }
+
+  return projections.reduce((total, projection) => {
+    const month = projection?.month;
+    if (typeof month !== "string" || month < fromMonth) {
+      return total;
+    }
+    const production = Number(projection?.production);
+    return Number.isFinite(production) ? total + production : total;
+  }, 0);
+}

--- a/src/lib/utils/supplyHelpers.ts
+++ b/src/lib/utils/supplyHelpers.ts
@@ -5,6 +5,11 @@
  */
 
 import { get } from "svelte/store";
+import { MIN_PURCHASABLE_WEI } from "$lib/utils/supplyThresholds";
+export {
+  MIN_PURCHASABLE_TOKENS,
+  isEffectivelySoldOut,
+} from "$lib/utils/supplyThresholds";
 import { sfts } from "$lib/stores";
 import { sftRepository } from "$lib/data/repositories";
 import { catalogService } from "$lib/services/CatalogService";
@@ -98,10 +103,11 @@ export function hasAvailableSupplySync(token: TokenMetadata): boolean {
   const maxSupply = catalogService.getTokenMaxSupply(token.contractAddress);
 
   if (maxSupply) {
-    // Use accurate calculation when maxSupply is available
+    // Use accurate calculation when maxSupply is available. Ignore rounding
+    // dust — see MIN_PURCHASABLE_TOKENS.
     const totalShares = BigInt(sft.totalShares);
     const maxSupplyBig = BigInt(maxSupply);
-    return totalShares < maxSupplyBig;
+    return maxSupplyBig - totalShares >= MIN_PURCHASABLE_WEI;
   } else {
     // Fallback heuristic: assume tokens are available unless minted supply is very high
     const totalShares = BigInt(sft.totalShares);

--- a/src/lib/utils/supplyThresholds.ts
+++ b/src/lib/utils/supplyThresholds.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure supply thresholds, deliberately free of store/service imports so that
+ * callers (and tests) don't drag in the catalog service just to ask whether a
+ * token is sold out.
+ */
+
+/**
+ * Smallest supply worth offering, in whole tokens.
+ *
+ * Minting leaves rounding dust behind: ALB-WR1-R2 is capped at 36,000 and has
+ * 35,999.999999999999998 minted, i.e. 2,000 wei — 0.000000000000002 tokens —
+ * "available". Treating that as purchasable keeps a Buy button on a sold-out
+ * token and makes every fully-diluted return calculation divide by ~zero,
+ * which trips the IRR divergence guard and renders as "<0%".
+ */
+export const MIN_PURCHASABLE_TOKENS = 1;
+
+export const MIN_PURCHASABLE_WEI = BigInt(MIN_PURCHASABLE_TOKENS) * 10n ** 18n;
+
+/**
+ * True when the remaining supply is dust — nothing meaningful left to buy.
+ *
+ * Returns false for undefined/null: unknown availability is not a claim that
+ * the token is sold out.
+ *
+ * @param availableSupply Remaining supply as a whole-token count.
+ */
+export function isEffectivelySoldOut(
+  availableSupply: number | undefined | null,
+): boolean {
+  if (availableSupply === undefined || availableSupply === null) {
+    return false;
+  }
+  return (
+    !Number.isFinite(availableSupply) ||
+    availableSupply < MIN_PURCHASABLE_TOKENS
+  );
+}

--- a/src/routes/(main)/assets/[id]/+page.svelte
+++ b/src/routes/(main)/assets/[id]/+page.svelte
@@ -36,7 +36,7 @@ import {
 } from 'chart.js';
 import { onDestroy } from 'svelte';
 import { useQueryClient } from '@tanstack/svelte-query';
-import { hasAvailableSupplySync } from '$lib/utils/supplyHelpers';
+import { hasAvailableSupplySync, isEffectivelySoldOut } from '$lib/utils/supplyHelpers';
 
 // Only bar charts are rendered on this page (revenue history), so register
 // just the pieces that chart needs instead of the full chart.js registerables
@@ -1458,7 +1458,8 @@ async function handlePurchaseSuccess() {
 										{@const cashflows = monthlyCashflows.map(m => m.cashflow)}
 										{@const monthlyIRR = calculateIRR(cashflows)}
 										{@const remainingIRR = monthlyIRR > -0.99 ? (Math.pow(1 + monthlyIRR, 12) - 1) * 100 : -99}
-										{@const fullyDilutedRemainingIRR = calculateFullyDilutedReturns(token, defaultOilPrice, supply?.mintedSupply ?? 0, supply?.availableSupply ?? 0)}
+										{@const soldOut = isEffectivelySoldOut(supply?.availableSupply)}
+										{@const fullyDilutedRemainingIRR = soldOut ? 0 : calculateFullyDilutedReturns(token, defaultOilPrice, supply?.mintedSupply ?? 0, supply?.availableSupply ?? 0)}
 
 										<h5 class="text-sm font-extrabold text-black uppercase tracking-wider mb-4 pt-6">
 											Returns @${defaultOilPrice} {crudeBenchmark} Oil Price
@@ -1469,8 +1470,13 @@ async function handlePurchaseSuccess() {
 												<span class="text-xl font-extrabold text-primary">{formatSmartReturn(remainingIRR)}</span>
 											</div>
 											<div class="text-center p-3 bg-white">
-												<span class="text-xs font-medium text-black opacity-70 block mb-1">Fully Diluted</span>
-												<span class="text-xl font-extrabold text-primary">{formatSmartReturn(fullyDilutedRemainingIRR)}</span>
+												{#if soldOut}
+													<span class="text-xs font-medium text-black opacity-70 block mb-1">Availability</span>
+													<span class="text-xl font-extrabold text-black">Sold Out</span>
+												{:else}
+													<span class="text-xs font-medium text-black opacity-70 block mb-1">Fully Diluted</span>
+													<span class="text-xl font-extrabold text-primary">{formatSmartReturn(fullyDilutedRemainingIRR)}</span>
+												{/if}
 											</div>
 											<div class="text-center p-3 bg-white border-l border-light-gray relative overflow-visible" style="border-left-width: 1.5px;">
 												<div class="flex items-center justify-center gap-1 mb-1">
@@ -1488,7 +1494,7 @@ async function handlePurchaseSuccess() {
 													</span>
 													{#if showTooltip === 'lifetime-tooltip-' + token.contractAddress}
 														<div class="absolute bottom-full left-1/2 transform -translate-x-1/2 bg-black text-white p-2 rounded-none text-xs whitespace-nowrap z-[1000] mb-[5px]">
-															Return from holding token since launch, assuming current supply
+															Return since launch, including payouts already made to earlier holders. Informational only, not a forward-looking return.
 														</div>
 													{/if}
 												</div>

--- a/src/routes/(main)/portfolio/+page.svelte
+++ b/src/routes/(main)/portfolio/+page.svelte
@@ -1103,24 +1103,58 @@ function percentageDisplay(value: number): string {
 		void loadSftData();
 	}
 	
+	// Payouts land ~2 months after the accrual month (June accrual paid early
+	// August). Shared by the history chart and the cash flow chart so the two
+	// cover the same months.
+	const PAYOUT_RECEIPT_LAG_MONTHS = 2;
+
+	function addMonths(monthStr: string, offset: number): string {
+		const [year, month] = monthStr.split('-').map(Number);
+		const date = new Date(Date.UTC(year, month - 1 + offset, 1));
+		return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+	}
+
 	function getPayoutChartData(holding: PortfolioHolding): HistoryPoint[] {
-		if (!holding.claimHistory || holding.claimHistory.length === 0) {
+		// Sourced from metadata payoutData, NOT claimHistory. claimHistory holds
+		// only what this wallet has actually claimed, so any month that was paid
+		// but not yet claimed would render as $0 — asserting "no payout" when
+		// there was one. payoutData covers every month, claimed or not.
+		const payoutData = holding.pinnedMetadata?.payoutData;
+		if (!Array.isArray(payoutData) || payoutData.length === 0) {
 			return [];
 		}
 
-		// Aggregate by calendar month. Several claims can resolve to the same
-		// month (the metadata legitimately carries more than one payout entry
-		// for a month, e.g. a catch-up distribution), and charting them as
-		// separate points produced duplicate axis labels like "Jun, Jun".
+		const claimAmountByOrderHash: Record<string, number> = {};
+		for (const claim of holding.claimHistory ?? []) {
+			if (!claim.orderHash) continue;
+			const claimAmount = Number(claim.amount);
+			if (!Number.isFinite(claimAmount)) continue;
+			claimAmountByOrderHash[claim.orderHash.toLowerCase()] = claimAmount;
+		}
+
+		// Aggregate by month: the metadata legitimately carries more than one
+		// payout entry for a month (e.g. a catch-up tranche alongside the regular
+		// royalty), which previously produced duplicate axis labels like "Jun, Jun".
 		const totalsByMonth: Record<string, number> = {};
-		for (const claim of holding.claimHistory) {
-			if (!claim.date || !claim.amount) continue;
-			const date = new Date(claim.date);
-			if (Number.isNaN(date.getTime())) continue;
-			const amount = Number(claim.amount);
-			if (!Number.isFinite(amount)) continue;
-			const monthKey = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
-			totalsByMonth[monthKey] = (totalsByMonth[monthKey] ?? 0) + amount;
+		for (const payout of payoutData) {
+			const month = payout.month;
+			if (!month) continue;
+
+			const orderHash = payout.tokenPayout?.orderHash?.toLowerCase();
+			const actualAmount = orderHash ? claimAmountByOrderHash[orderHash] : undefined;
+			const payoutPerToken = resolvePayoutPerToken(
+				payout.tokenPayout?.payoutPerToken,
+				payout.tokenPayout?.totalPayout ?? 0,
+				holding.mintedSupply
+			);
+			// Prefer the real claimed amount; fall back to the per-token estimate.
+			const value = actualAmount !== undefined
+				? actualAmount
+				: payoutPerToken * holding.tokensOwned;
+			if (!Number.isFinite(value) || value <= 0) continue;
+
+			const receivedMonth = addMonths(month, PAYOUT_RECEIPT_LAG_MONTHS);
+			totalsByMonth[receivedMonth] = (totalsByMonth[receivedMonth] ?? 0) + value;
 		}
 
 		const months = Object.keys(totalsByMonth).sort();
@@ -1128,10 +1162,9 @@ function percentageDisplay(value: number): string {
 			return [];
 		}
 
-		// Emit a point for every month in the range, including months with no
-		// payout. The chart's x-axis is categorical (one slot per point), so
-		// skipping empty months silently compresses time — Nov would sit next
-		// to Apr looking like consecutive periods.
+		// Emit a point for every month in the range. The chart's x-axis is
+		// categorical (one slot per point), so skipping months silently
+		// compresses time — Nov would sit next to Apr looking consecutive.
 		const points: HistoryPoint[] = [];
 		const [firstYear, firstMonth] = months[0].split('-').map(Number);
 		const [lastYear, lastMonth] = months[months.length - 1].split('-').map(Number);
@@ -1643,11 +1676,6 @@ function percentageDisplay(value: number): string {
 
 					// Process payouts from metadata payoutData (source of truth for when payouts were distributed)
 					// Apply 2-month offset: e.g., August payout is received in October
-					const addMonths = (monthStr: string, offset: number): string => {
-						const [year, month] = monthStr.split('-').map(Number);
-						const date = new Date(year, month - 1 + offset, 1);
-						return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-					};
 
 					for (const holding of holdings) {
 						const payoutData = holding.pinnedMetadata?.payoutData;
@@ -1687,7 +1715,7 @@ function percentageDisplay(value: number): string {
 								const hasRealClaim =
 									!!payoutOrderHash && claimAmountByOrderHash[payoutOrderHash] !== undefined;
 								if (month && (payoutPerToken > 0 || hasRealClaim)) {
-									const receivedMonth = addMonths(month, 2); // 2-month offset
+									const receivedMonth = addMonths(month, PAYOUT_RECEIPT_LAG_MONTHS);
 									const orderHash = payout.tokenPayout?.orderHash?.toLowerCase();
 									const actualAmount = orderHash ? claimAmountByOrderHash[orderHash] : undefined;
 									const userPayout = actualAmount !== undefined

--- a/src/routes/(main)/portfolio/+page.svelte
+++ b/src/routes/(main)/portfolio/+page.svelte
@@ -35,6 +35,7 @@ import type { Hex } from 'viem';
 import { getTokenBalancesOnchain } from '$lib/data/clients/onchain';
 import { ENERGY_FIELDS } from '$lib/network';
 import { getClaimsBundle } from '$lib/utils/claimsBundle';
+import { resolvePayoutPerToken } from '$lib/utils/payoutHelpers';
 import { onMount } from 'svelte';
 
 onMount(() => {
@@ -123,6 +124,7 @@ interface PortfolioHolding {
 	asset?: PinnedMetadata['asset']; // Token's embedded asset data (for returns estimation)
 	sharedAsset?: import('$lib/types/uiTypes').Asset; // Shared Asset object (for display)
 	sftAddress: string;
+	mintedSupply: string; // SFT totalShares (wei) — divisor for per-token payouts
 	claimHistory: ClaimsHistoryItem[];
 	pinnedMetadata: PinnedMetadata;
 	expectedNextPayout: Date | null;
@@ -991,6 +993,7 @@ function percentageDisplay(value: number): string {
 							asset,
 							sharedAsset,
 							sftAddress: sft.id,
+							mintedSupply: sft.totalShares ?? '0',
 							claimHistory: sftClaims,
 							pinnedMetadata: pinnedMetadata,
 							expectedNextPayout
@@ -1015,7 +1018,10 @@ function percentageDisplay(value: number): string {
 			for (const claim of claimHistory) {
 				if (claim.date && claim.amount) {
 					const date = new Date(claim.date);
-					const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+					// Claim dates are normalised to UTC midnight (`${month}-01T00:00:00.000Z`)
+					// above, so read them in UTC — local getters bucket every payout into
+					// the previous month for anyone west of UTC.
+					const monthKey = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
 					const amount = Number(claim.amount);
 					monthlyPayoutTotals[monthKey] = (monthlyPayoutTotals[monthKey] ?? 0) + (Number.isFinite(amount) ? amount : 0);
 				}
@@ -1101,14 +1107,44 @@ function percentageDisplay(value: number): string {
 		if (!holding.claimHistory || holding.claimHistory.length === 0) {
 			return [];
 		}
-		
-		return holding.claimHistory
-			.filter((claim) => claim.date && claim.amount)
-			.map((claim) => ({
-				date: new Date(claim.date).toISOString().split('T')[0],
-				value: Number(claim.amount)
-			}))
-			.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+		// Aggregate by calendar month. Several claims can resolve to the same
+		// month (the metadata legitimately carries more than one payout entry
+		// for a month, e.g. a catch-up distribution), and charting them as
+		// separate points produced duplicate axis labels like "Jun, Jun".
+		const totalsByMonth: Record<string, number> = {};
+		for (const claim of holding.claimHistory) {
+			if (!claim.date || !claim.amount) continue;
+			const date = new Date(claim.date);
+			if (Number.isNaN(date.getTime())) continue;
+			const amount = Number(claim.amount);
+			if (!Number.isFinite(amount)) continue;
+			const monthKey = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+			totalsByMonth[monthKey] = (totalsByMonth[monthKey] ?? 0) + amount;
+		}
+
+		const months = Object.keys(totalsByMonth).sort();
+		if (months.length === 0) {
+			return [];
+		}
+
+		// Emit a point for every month in the range, including months with no
+		// payout. The chart's x-axis is categorical (one slot per point), so
+		// skipping empty months silently compresses time — Nov would sit next
+		// to Apr looking like consecutive periods.
+		const points: HistoryPoint[] = [];
+		const [firstYear, firstMonth] = months[0].split('-').map(Number);
+		const [lastYear, lastMonth] = months[months.length - 1].split('-').map(Number);
+		const cursor = new Date(Date.UTC(firstYear, firstMonth - 1, 1));
+		const end = new Date(Date.UTC(lastYear, lastMonth - 1, 1));
+
+		while (cursor.getTime() <= end.getTime()) {
+			const monthKey = `${cursor.getUTCFullYear()}-${String(cursor.getUTCMonth() + 1).padStart(2, '0')}`;
+			points.push({ date: `${monthKey}-01`, value: totalsByMonth[monthKey] ?? 0 });
+			cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+		}
+
+		return points;
 	}
 
 	async function connectWallet() {
@@ -1638,8 +1674,19 @@ function percentageDisplay(value: number): string {
 
 							for (const payout of payoutData) {
 								const month = payout.month;
-								const payoutPerToken = payout.tokenPayout?.payoutPerToken ?? 0;
-								if (month && payoutPerToken > 0) {
+								// `payoutPerToken` is a removed schema field (0 on everything pinned
+								// from 2026-02 on), so derive it from totalPayout and fixed supply.
+								const payoutPerToken = resolvePayoutPerToken(
+									payout.tokenPayout?.payoutPerToken,
+									payout.tokenPayout?.totalPayout ?? 0,
+									holding.mintedSupply
+								);
+								// A month with a genuine on-chain claim must never be dropped just
+								// because the per-token estimate is unavailable.
+								const payoutOrderHash = payout.tokenPayout?.orderHash?.toLowerCase();
+								const hasRealClaim =
+									!!payoutOrderHash && claimAmountByOrderHash[payoutOrderHash] !== undefined;
+								if (month && (payoutPerToken > 0 || hasRealClaim)) {
 									const receivedMonth = addMonths(month, 2); // 2-month offset
 									const orderHash = payout.tokenPayout?.orderHash?.toLowerCase();
 									const actualAmount = orderHash ? claimAmountByOrderHash[orderHash] : undefined;


### PR DESCRIPTION
Follow-up to #180. While checking the June rewards data locally, the portfolio charts turned out to be misreporting — which led to a cluster of related fixes across payouts, supply and returns.

## Why the charts were wrong

`payoutPerToken` was removed from the pinned-metadata schema, so every entry pinned from **2026-02 onward carries `0`**. `totalPayout` is correct throughout (June matches this PR's parent exactly: R1 857.925, R2 3018.679).

| | before | after |
|---|---|---|
| Cash flow chart | stopped at Mar 2026 | runs to current |
| History chart x-axis | `Oct 2025, Nov, Apr 2026, Jun, Jun` | one point per month, no gaps |
| Exp. Remaining | 8,645 boe | **4,026 boe** |
| Returns row | `Current <0% / Fully Diluted 26%` | `Current <0% / Sold Out / Lifetime 26%` |

## Changes

**Per-token payouts are derived, not read.** Supply is fixed, so `totalPayout / mintedSupply`. Validated against ALB-WR1-R1 (minted at exactly 12,000) — its old pinned values reproduce to 5dp. Legacy non-zero pinned values still win, because for a partially-sold token dividing by *today's* supply retroactively shrinks historical months.

**Cash flow no longer drops months.** The guard checked the per-token estimate *before* looking up the wallet's real claimed amount, so a month with a genuine on-chain claim was dropped whenever the estimate was zero.

**History chart aggregates by month** and emits every month in range. It previously plotted one point per claim on a categorical axis, so two claims in a month gave duplicate `Jun, Jun` labels and empty months got no slot — Nov sat beside Apr looking consecutive. Also fixes month bucketing that read UTC-midnight dates with local getters (previous-month for anyone west of UTC).

**Dust supply now counts as sold out.** Verified on chain: R1 is 12,000/12,000; R2 has **2,000 wei** left against its 36,000 cap — 0.000000000000002 tokens. `minted < max` was true for that dust, so a sold-out token kept a Buy button and every fully-diluted return divided by ~zero, tripping the IRR divergence guard and rendering `<0%`.

**"Fully Diluted" was two different metrics.** The asset card used `calculateLifetimeIRR`; the detail page used `calculateFullyDilutedReturns` — under the same label. That produced `Current <0% / Fully Diluted 26%`, which is impossible since more tokens can only mean less cash per token. Both now show "Sold Out" in that slot when supply is dust, and a real fully-diluted figure otherwise. Lifetime is retained for information only, with its tooltip corrected.

**"Exp. Remaining" counted the past.** It summed all 32 whole-life projections (2025-05 → 2027-12), roughly half already produced and paid.

## Deliberately not changed

- **Breakeven oil price** — still on the whole-life production basis (reads \$55.53; remaining-basis would be \$119.23).
- **`Current <0%`** — arithmetically real at the hardcoded \$65 oil, not a display bug.
- The hardcoded \$65 assumption vs \$84–\$119 realised prices in the same metadata.

## Verification

221 tests pass (33 new), build clean, typecheck unchanged from baseline (2 pre-existing errors on `main`). Confirmed in a browser against live Base mainnet data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK7GMn9FL3VZnBUgAAErmD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asset and token views now show remaining production instead of planned totals.
  * Sold-out tokens are clearly labeled, with purchase options hidden when unavailable.
  * Return metrics now include lifetime and fully diluted estimates.
  * Asset details clarify total token releases issued.
  * Portfolio payout calculations and history charts are more complete and accurate, including zero-value months.

* **Bug Fixes**
  * Improved payout calculations when per-token values are unavailable.
  * Very small remaining supplies are now correctly treated as sold out.
  * Production and payout displays handle missing or invalid data more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->