### PR TITLE
fix(rpc): replace incapable RPCs and stop reporting broadcast claims as failed

### DIFF
--- a/src/routes/(main)/claims/+page.svelte
+++ b/src/routes/(main)/claims/+page.svelte
@@ -46,6 +46,10 @@
 	let confirmingTarget: 'all' | string | null = null;
 	let verifyingTarget: 'all' | string | null = null;
 	let claimSuccess = false;
+	// Hashes that are on chain but whose receipt we could not read back. The claim
+	// itself succeeded; only our confirmation of it failed. Kept separate from
+	// claimSuccess so the banner can say "submitted" rather than overclaiming.
+	let unconfirmedTxHashes: string[] = [];
 	let dataLoadError = false;
 
 	let holdings: ClaimsHoldingsGroup[] = [];
@@ -310,7 +314,18 @@
 		if (isRpcRateLimitError(error)) {
 			return 'Base RPC rate limit reached. Wait a moment and try again, or retry one claim at a time.';
 		}
-		return error instanceof Error ? error.message : 'Claim transaction failed';
+		// viem's HttpRequestError message is a multi-line dump carrying the RPC URL and
+		// the raw JSON-RPC request body. Surfacing that verbatim is how a user ended up
+		// reading "Status: 403 ... eth_getTransactionReceipt ..." out of an alert box.
+		// Prefer viem's one-line shortMessage; keep the full object in the console.
+		const shortMessage = (error as { shortMessage?: string })?.shortMessage;
+		if (typeof shortMessage === 'string' && shortMessage.length > 0) {
+			return shortMessage;
+		}
+		if (error instanceof Error && error.message && !error.message.includes('\n')) {
+			return error.message;
+		}
+		return 'Claim transaction failed. Please try again — see the browser console for details.';
 	}
 
 	/** Reload claimable holdings from chain/subgraph immediately before submitting. */
@@ -395,7 +410,19 @@
 		}
 
 		confirmingTarget = confirmLabel;
-		await waitForTransactionReceipt($wagmiConfig, { hash, confirmations: 2 });
+		try {
+			await waitForTransactionReceipt($wagmiConfig, { hash, confirmations: 2 });
+		} catch (error) {
+			// The transaction is ALREADY BROADCAST — `hash` was returned by
+			// writeContract/sendV6Claim above, so the wallet has signed and submitted it.
+			// Failing to read the receipt back means we could not CONFIRM the claim, not
+			// that the claim failed. This used to propagate and get reported as
+			// "Claim transaction failed", telling users their claim had failed when it
+			// had in fact succeeded — see the publicnode eth_getTransactionReceipt 403.
+			// Treated like the subgraph-indexing wait below: note it and carry on.
+			console.warn('Could not confirm claim receipt; tx is already on chain:', hash, error);
+			unconfirmedTxHashes = [...unconfirmedTxHashes, hash];
+		}
 		try {
 			await waitForTransactionInSubgraph(hash, orderbookAddress);
 		} catch {
@@ -438,6 +465,7 @@
 	async function claimAllPayouts() {
 		claimingTarget = 'all';
 		verifyingTarget = 'all';
+		unconfirmedTxHashes = [];
 		try {
 			const freshHoldings = await refreshClaimableHoldings();
 			const hasClaimable = freshHoldings.some((g) => g.holdings.length > 0);
@@ -492,6 +520,7 @@
 	async function handleClaimSingle(group: ClaimsHoldingsGroup) {
 		claimingTarget = group.tokenAddress;
 		verifyingTarget = group.tokenAddress;
+		unconfirmedTxHashes = [];
 		try {
 			const freshHoldings = await refreshClaimableHoldings();
 			const claimGroup = freshHoldings.find(
@@ -679,14 +708,38 @@
 			{/if}
 
 			{#if claimSuccess && claimingTarget === null && confirmingTarget === null}
-				<div class="text-center mt-4 p-4 bg-green-100 text-green-800 rounded-none max-w-md mx-auto relative">
-					<button
-						class="absolute top-2 right-2 text-green-600 hover:text-green-800 text-lg leading-none"
-						on:click={() => claimSuccess = false}
-						aria-label="Dismiss"
-					>×</button>
-					✅ Claim successful! Tokens have been sent to your wallet.
-				</div>
+				{#if unconfirmedTxHashes.length > 0}
+					<!-- Broadcast but unconfirmed: the transaction is on chain, we just could
+					     not read its receipt back. Say exactly that and link the explorer,
+					     rather than claiming success we have not verified. -->
+					<div class="text-center mt-4 p-4 bg-amber-100 text-amber-900 rounded-none max-w-md mx-auto relative">
+						<button
+							class="absolute top-2 right-2 text-amber-700 hover:text-amber-900 text-lg leading-none"
+							on:click={() => { claimSuccess = false; unconfirmedTxHashes = []; }}
+							aria-label="Dismiss"
+						>×</button>
+						Claim submitted. We couldn't confirm it on-chain just now, so it may still be
+						settling — your tokens should arrive shortly. Check the transaction:
+						<span class="block mt-2">
+							{#each unconfirmedTxHashes as txHash (txHash)}
+								<a
+									class="underline break-all"
+									href={`https://basescan.org/tx/${txHash}`}
+									target="_blank"
+									rel="noopener noreferrer">{txHash.slice(0, 10)}…{txHash.slice(-8)}</a>
+							{/each}
+						</span>
+					</div>
+				{:else}
+					<div class="text-center mt-4 p-4 bg-green-100 text-green-800 rounded-none max-w-md mx-auto relative">
+						<button
+							class="absolute top-2 right-2 text-green-600 hover:text-green-800 text-lg leading-none"
+							on:click={() => claimSuccess = false}
+							aria-label="Dismiss"
+						>×</button>
+						✅ Claim successful! Tokens have been sent to your wallet.
+					</div>
+				{/if}
 			{/if}
 
 			<!-- Payout email alerts: signup lives where payout attention already is;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,13 +11,27 @@
 	import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
 
 	// Prefer dedicated / third-party RPCs; mainnet.base.org is last (strict 429 limits).
+	//
+	// Every endpoint here was probed for the two methods this app actually needs —
+	// eth_getTransactionReceipt (claim confirmation) and eth_getLogs (claim history) —
+	// rather than for mere liveness. Three previous entries were removed because they
+	// cannot serve them:
+	//   base-rpc.publicnode.com   eth_getTransactionReceipt -> HTTP 403, 0/8 success.
+	//                             Free tier gates the method outright: a hash that does
+	//                             not exist returns the same "Archive requests require a
+	//                             personal token" error, so it never performs a lookup.
+	//                             This was the primary RPC, so EVERY claim confirmation
+	//                             began with a guaranteed failure.
+	//   base.llamarpc.com         HTTP 521 — origin offline.
+	//   base.meowrpc.com          "The method eth_getLogs is not supported."
+	// base-mainnet.public.blastapi.io was dropped too: it serves receipts but rate-limits
+	// eth_getLogs. The five below returned 8/8 on receipts (110–228ms p50).
 	const rpcList = [
 		publicEnv.PUBLIC_BASE_RPC_URL,
-		"https://base-rpc.publicnode.com",
-		"https://base.llamarpc.com",
-		"https://base.meowrpc.com",
-		"https://base-mainnet.public.blastapi.io",
 		"https://gateway.tenderly.co/public/base",
+		"https://base-pokt.nodies.app",
+		"https://base.drpc.org",
+		"https://1rpc.io/base",
 		"https://mainnet.base.org"
 	].filter((url): url is string => typeof url === "string" && url.length > 0);
 
@@ -67,7 +81,17 @@
 					weights: {
 						latency: 0.2,
 						stability: 0.8  // Prioritize stability over latency
-					}
+					},
+					// viem's default ranking probe is net_listening, which measures nothing
+					// this app depends on and actively mis-ranked the pool: publicnode
+					// answered it `true` in ~175ms and was pinned to the FRONT despite
+					// failing every eth_getTransactionReceipt, while mainnet.base.org
+					// answers it "rpc method is unsupported" (HTTP 403) and was scored a
+					// failure and pinned to the BACK despite serving receipts 8/8.
+					// With stability weighted 0.8 that ordering was self-reinforcing, so
+					// reordering the list alone would have been undone within one interval.
+					// eth_chainId is supported by every endpoint in the list.
+					ping: ({ transport }) => transport.request({ method: 'eth_chainId' })
 				},
 				retryCount: 5  // Try up to 5 different RPCs before failing
 			}


### PR DESCRIPTION
A colleague hit `HTTP 403 … eth_getTransactionReceipt … "Archive requests require a personal token"` while claiming. **The claim had actually succeeded.** Two independent bugs, both fixed here.

## 1. The RPC pool could not serve the methods the app needs

Every endpoint probed for the two methods this app actually depends on — `eth_getTransactionReceipt` (claim confirmation) and `eth_getLogs` (claim history) — rather than for liveness:

| endpoint | was | receipts | getLogs |
|---|---|---|---|
| `base-rpc.publicnode.com` | **1st** | **0/8 — HTTP 403** | ok (filtered) |
| `base.llamarpc.com` | 2nd | — | — **HTTP 521, offline** |
| `base.meowrpc.com` | 3rd | fails | **"not supported"** |
| `base-mainnet.public.blastapi.io` | 4th | 8/8 | rate-limited |
| `gateway.tenderly.co/public/base` | 5th | **8/8 @ 110ms** | ok |
| `mainnet.base.org` | **last** | **8/8 @ 161ms** | ok |

publicnode's free tier **gates `eth_getTransactionReceipt` outright** — a hash that doesn't exist returns the *identical* "archive" error, proving it never performs a lookup. The message is misleading: this is a paid-tier method gate, not an archive-depth limit.

`PUBLIC_BASE_RPC_URL` is unset in production, so publicnode was first and **every claim confirmation began with a guaranteed 403**. This was deterministic, not flaky.

Replaced with five endpoints measured at 8/8 on receipts. `mainnet.base.org` stays **last**, preserving the existing note about its 429 limits — 8 requests from one IP can't disprove a rate limit under real load.

## 2. The ranker was actively enforcing the wrong order

viem ranks fallback transports by pinging **`net_listening`**, which measures nothing this app depends on:

| endpoint | `net_listening` | ranked | reality |
|---|---|---|---|
| publicnode | `true` (200) | **healthy → front** | 0/8 receipts |
| mainnet.base.org | `-32601` (**403**) | **failed → back** | 8/8 receipts |

With `weights {latency 0.2, stability 0.8}` that ordering is self-reinforcing — **reordering the list alone would have been undone within one 60s interval.** Now pings `eth_chainId`, supported by every endpoint in the list.

## 3. A broadcast transaction was reported as a failed claim

`waitForTransactionReceipt` ran unguarded *after* `writeContract` had already returned a hash. Any receipt-read failure propagated to `alert(formatClaimError(error))` with `claimSuccess = false` — telling users their claim failed when it was already on chain.

It now behaves like the subgraph-indexing wait directly below it: record the hash as unconfirmed and continue. The banner says *"Claim submitted. We couldn't confirm it on-chain just now…"* with a Basescan link, instead of either overclaiming success or asserting a failure that didn't happen.

**This matters independently of the RPC fix** — any transient failure during the two confirmations reproduced the same false failure.

`formatClaimError` also no longer returns viem's raw multi-line `HttpRequestError` message, which embeds the RPC URL and JSON-RPC request body. That is literally what the user read out of the alert box. It now prefers viem's one-line `shortMessage` and keeps the full object in the console.

## Verification

- **192/192 tests pass** (23 files)
- production build clean
- lint **unchanged from baseline** — 27 problems, 1 pre-existing error (`new Set` at claims:93, untouched)
- `svelte-check` **unchanged** — 2 pre-existing errors, none new; the `ping` option type-checks

## Not included

`PUBLIC_BASE_RPC_URL` is still unset. This change makes the free pool viable on its own, so setting it is now an optional upgrade rather than a fix — and it avoids the question of putting an Alchemy key in a client-visible var. Left for you to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK7GMn9FL3VZnBUgAAErmD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Claim submitted” status for claims broadcast successfully when confirmation details are temporarily unavailable.
  * Added explorer links for unconfirmed claim submissions.
  * Improved claim error messages with concise, user-friendly RPC details.

* **Bug Fixes**
  * Claims no longer fail when transaction receipt information cannot be read.
  * Improved RPC fallback reliability by updating endpoints and connection checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->