### PR TITLE
feat(assets): show lifetime return on sold-out releases

### DIFF
--- a/src/lib/components/patterns/assets/AssetCard.svelte
+++ b/src/lib/components/patterns/assets/AssetCard.svelte
@@ -171,10 +171,14 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 			</PrimaryButton>
 		</div>
 
-		<!-- Available Tokens Section - Mobile Responsive -->
-		{#if hasAvailableTokens}
+		<!-- Token Releases Section - Mobile Responsive -->
+		<!-- Rendered whenever the asset has any releases, NOT only when something is still
+		     buyable. Gating this on hasAvailableTokens meant a fully sold-out asset showed
+		     no token rows at all, which hid the lifetime return — the one figure that is
+		     most worth showing once a release is gone. -->
+		{#if tokensArray.length > 0}
 		<div class={tokensSectionClasses}>
-			<h4 class={tokensTitleClasses}>Available Tokens</h4>
+			<h4 class={tokensTitleClasses}>{hasAvailableTokens ? 'Available Tokens' : 'Token Releases'}</h4>
 			<div class="flex flex-col">
 				{#if tokensArray.length > 2 && canScrollUp}
 					<!-- Top scroll indicator - hidden on mobile -->
@@ -225,30 +229,40 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 							<div class="flex flex-col items-start gap-2 border-l border-gray-300 pl-2">
 								<div class="text-sm font-bold text-black text-left mb-1">Returns</div>
 								<div class="flex items-center gap-3">
-									<div class="flex items-center gap-1.5">
-										<span class="text-xs text-gray-500 font-medium">Current:</span>
-										<span class="text-base text-primary font-extrabold">
-											<FormattedReturn value={currentReturns} />
-										</span>
-									</div>
 									{#if soldOut}
+										<!-- Sold out: Current and Fully Diluted are forward-looking returns on
+										     a purchase that cannot be made, so they are omitted rather than
+										     shown as numbers nobody can act on. Lifetime leads instead — the
+										     realised track record of the release. -->
 										<div class="flex items-center gap-1.5">
 											<span class="text-xs font-bold text-black uppercase tracking-wider">Sold Out</span>
 										</div>
+										<div class="flex items-center gap-1.5" title="Total return since this release launched, including payouts already made to earlier holders. A record of what this release has paid, not a return available today.">
+											<span class="text-xs text-gray-500 font-medium">Lifetime:</span>
+											<span class="text-base text-primary font-extrabold">
+												<FormattedReturn value={lifetimeReturns} />
+											</span>
+										</div>
 									{:else}
+										<div class="flex items-center gap-1.5">
+											<span class="text-xs text-gray-500 font-medium">Current:</span>
+											<span class="text-base text-primary font-extrabold">
+												<FormattedReturn value={currentReturns} />
+											</span>
+										</div>
 										<div class="flex items-center gap-1.5">
 											<span class="text-xs text-gray-500 font-medium">Fully Diluted:</span>
 											<span class="text-base text-primary font-extrabold">
 												<FormattedReturn value={fullyDilutedReturns} />
 											</span>
 										</div>
+										<div class="flex items-center gap-1.5" title="Return since launch, including payouts already made to earlier holders. Informational only — not a forward-looking return.">
+											<span class="text-xs text-gray-500 font-medium">Lifetime:</span>
+											<span class="text-base text-gray-500 font-extrabold">
+												<FormattedReturn value={lifetimeReturns} />
+											</span>
+										</div>
 									{/if}
-									<div class="flex items-center gap-1.5" title="Return since launch, including payouts already made to earlier holders. Informational only — not a forward-looking return.">
-										<span class="text-xs text-gray-500 font-medium">Lifetime:</span>
-										<span class="text-base text-gray-500 font-extrabold">
-											<FormattedReturn value={lifetimeReturns} />
-										</span>
-									</div>
 								</div>
 								<button
 									class="text-base font-semibold text-secondary hover:text-primary transition-colors"
@@ -269,40 +283,51 @@ import { Card, CardContent, PrimaryButton } from '$lib/components/components';
 								<div class="border-l border-gray-300 pl-2">
 									<div class="text-xs font-bold text-black mb-1 text-left">Returns</div>
 									<div class="flex flex-col gap-1 text-xs">
-										<div class="flex items-center gap-1">
-											<span class="text-gray-500">Current:</span>
-											<span class="text-primary font-extrabold">
-												<FormattedReturn value={currentReturns} />
-											</span>
-										</div>
 										{#if soldOut}
 											<div class="flex items-center gap-1">
 												<span class="font-bold text-black uppercase tracking-wider">Sold Out</span>
 											</div>
+											<div class="flex items-center gap-1">
+												<span class="text-gray-500">Lifetime:</span>
+												<span class="text-primary font-extrabold">
+													<FormattedReturn value={lifetimeReturns} />
+												</span>
+											</div>
 										{:else}
+											<div class="flex items-center gap-1">
+												<span class="text-gray-500">Current:</span>
+												<span class="text-primary font-extrabold">
+													<FormattedReturn value={currentReturns} />
+												</span>
+											</div>
 											<div class="flex items-center gap-1">
 												<span class="text-gray-500">Diluted:</span>
 												<span class="text-primary font-extrabold">
 													<FormattedReturn value={fullyDilutedReturns} />
 												</span>
 											</div>
+											<div class="flex items-center gap-1">
+												<span class="text-gray-500">Lifetime:</span>
+												<span class="text-gray-500 font-extrabold">
+													<FormattedReturn value={lifetimeReturns} />
+												</span>
+											</div>
 										{/if}
-										<div class="flex items-center gap-1">
-											<span class="text-gray-500">Lifetime:</span>
-											<span class="text-gray-500 font-extrabold">
-												<FormattedReturn value={lifetimeReturns} />
-											</span>
-										</div>
 									</div>
 								</div>
 							</div>
 							<div class="flex flex-col gap-2">
-								<button
-									class="w-1/2 px-3 py-1.5 bg-black text-white text-xs font-bold rounded-none hover:bg-primary hover:scale-105 transition-all duration-200"
-									on:click|stopPropagation={() => handleBuyTokens(tokenItem.contractAddress)}
-								>
-									Buy
-								</button>
+								<!-- Guarded like its desktop counterpart. This was previously unreachable
+								     for a sold-out token only because the whole section was hidden; now
+								     that sold-out releases render, it needs its own check. -->
+								{#if !soldOut}
+									<button
+										class="w-1/2 px-3 py-1.5 bg-black text-white text-xs font-bold rounded-none hover:bg-primary hover:scale-105 transition-all duration-200"
+										on:click|stopPropagation={() => handleBuyTokens(tokenItem.contractAddress)}
+									>
+										Buy
+									</button>
+								{/if}
 								<button
 									class="text-sm font-semibold text-secondary hover:text-primary transition-colors text-left"
 									on:click|stopPropagation={() => openReturnsEstimator(tokenItem, mintedSupply, maxSupply)}

--- a/src/lib/utils/productionHelpers.spec.ts
+++ b/src/lib/utils/productionHelpers.spec.ts
@@ -76,8 +76,14 @@ describe("sumRemainingProduction", () => {
 // since it is the other half of the "dust" fix.
 describe("isEffectivelySoldOut (real on-chain supply)", () => {
   it("treats ALB-WR1-R2's 2,000 wei of leftover supply as sold out", () => {
-    // maxSupply 36,000 - minted 35,999.999999999999998
-    expect(isEffectivelySoldOut(36000 - 35999.999999999999998)).toBe(true);
+    // maxSupply 36,000e18 wei - minted 35,999,999,999,999,999,998,000 wei = 2,000 wei.
+    // Expressed as a token count directly rather than as `36000 - 35999.999999999999998`:
+    // that second literal is not representable as a double and silently rounds to exactly
+    // 36000, so the old assertion evaluated isEffectivelySoldOut(0) and merely duplicated
+    // the fully-minted case below instead of exercising the dust value at all.
+    const dustTokens = 2000 / 1e18;
+    expect(dustTokens).toBeGreaterThan(0); // guard: the value under test is genuinely non-zero
+    expect(isEffectivelySoldOut(dustTokens)).toBe(true);
   });
 
   it("treats a fully minted token as sold out", () => {

--- a/src/routes/(main)/assets/+page.svelte
+++ b/src/routes/(main)/assets/+page.svelte
@@ -71,7 +71,14 @@
 		loadTokenAndAssets();
 	}
 
-	$: visibleTokensWithAssets = showSoldOutAssets
+	$: availableCount = featuredTokensWithAssets.filter((item) => hasAvailableSupplySync(item.token)).length;
+	// With every release sold out, filtering to "available" empties the page and puts
+	// the lifetime returns behind a click. Show the sold-out assets instead of an empty
+	// state — their track record is the useful thing left to show. Derived, so it never
+	// fights the toggle or flips while data is still loading.
+	$: autoRevealSoldOut = availableCount === 0 && soldOutCount > 0;
+
+	$: visibleTokensWithAssets = (showSoldOutAssets || autoRevealSoldOut)
 		? featuredTokensWithAssets
 		: featuredTokensWithAssets.filter((item) => hasAvailableSupplySync(item.token));
 
@@ -152,8 +159,9 @@
 		{/if}
 	</HeroSection>
 
-	<!-- View Sold Out Assets Toggle -->
-	{#if !loading && featuredTokensWithAssets.length > 0}
+	<!-- View Sold Out Assets Toggle. Hidden when sold-out assets are all there is:
+	     with nothing available, "Hide" would leave an empty page. -->
+	{#if !loading && featuredTokensWithAssets.length > 0 && !autoRevealSoldOut}
 		{#if soldOutCount > 0 && !showSoldOutAssets}
 			<div class="text-center mt-8 sm:mt-12">
 				<SecondaryButton on:click={() => showSoldOutAssets 	= true}>

--- a/src/routes/(main)/assets/[id]/+page.svelte
+++ b/src/routes/(main)/assets/[id]/+page.svelte
@@ -308,8 +308,17 @@ let loadedAssetId: string | null = null;
 		return value;
 	}
 
+	// When nothing is available, collapsing the sold-out releases leaves the section
+	// empty and hides the lifetime return — the record of what the release actually
+	// paid, which is exactly what a visitor wants once they can no longer buy. So
+	// reveal them automatically when there is nothing else to show. Derived rather
+	// than assigned into showSoldOutTokens, so it cannot fight the toggle or flip
+	// mid-load while token data is still arriving.
+	$: autoRevealSoldOut = availableTokens.length === 0 && soldOutCount > 0;
 	// Tokens to display: available tokens, plus sold out if toggle is on
-	$: visibleTokens = showSoldOutTokens ? [...availableTokens, ...soldOutTokens] : availableTokens;
+	$: visibleTokens = (showSoldOutTokens || autoRevealSoldOut)
+		? [...availableTokens, ...soldOutTokens]
+		: availableTokens;
 	$: receiptsData = primaryToken?.asset?.receiptsData ?? [];
 // Use asset-level monthlyReports as primary source (selected from token with most recent receiptsData)
 // Fall back to primaryToken's receiptsData for backwards compatibility
@@ -1467,7 +1476,16 @@ async function handlePurchaseSuccess() {
 										<div class="grid grid-cols-3 gap-2 sm:gap-3 mb-3 overflow-visible">
 											<div class="text-center p-3 bg-white">
 												<span class="text-xs font-medium text-black opacity-70 block mb-1">Current</span>
-												<span class="text-xl font-extrabold text-primary">{formatSmartReturn(remainingIRR)}</span>
+												{#if soldOut}
+													<!-- Forward return on a purchase that cannot be made. R1 has already
+													     paid 77¢ of its 160¢ lifetime, so buying at $1 today prices as
+													     deeply negative and rendered as "<0%" next to "Sold Out" — which
+													     reads as a broken figure rather than an inapplicable one. N/A
+													     matches the returns estimator's sold-out treatment. -->
+													<span class="text-xl font-extrabold text-black opacity-40">N/A</span>
+												{:else}
+													<span class="text-xl font-extrabold text-primary">{formatSmartReturn(remainingIRR)}</span>
+												{/if}
 											</div>
 											<div class="text-center p-3 bg-white">
 												{#if soldOut}
@@ -1762,8 +1780,9 @@ async function handlePurchaseSuccess() {
 					{/if}
 				</div>
 
-				<!-- Sold Out Tokens Toggle -->
-				{#if soldOutCount > 0}
+				<!-- Sold Out Tokens Toggle. Suppressed when the sold-out releases are the
+				     only ones there are: "Hide" would empty the section entirely. -->
+				{#if soldOutCount > 0 && !autoRevealSoldOut}
 					<div class="mt-8 flex justify-center">
 						<button
 							class="px-6 py-3 bg-white border border-light-gray text-black font-semibold text-sm uppercase tracking-wider cursor-pointer transition-all duration-200 hover:bg-light-gray hover:border-black"


### PR DESCRIPTION
I built the previous sold-out work to the wrong spec. The lifetime return **was** implemented — but placed where it could never render for a fully sold-out asset, which is exactly the case where it matters as history and as evidence of what the release paid.

## Three gates were hiding it

| where | gate | effect |
|---|---|---|
| `AssetCard` | `{#if hasAvailableTokens}` | Tightening `hasAvailableSupplySync` to `MIN_PURCHASABLE_WEI` made this false for both R1 (0 available) and R2 (2,000 wei) — so the `Sold Out` / `Lifetime` rows became **unreachable code**. |
| `/assets` | filters to available | An all-sold-out catalogue rendered *"No Available Assets"* with everything behind a click. |
| `/assets/[id]` | `showSoldOutTokens = false` | With every token sold out, the returns block rendered nothing. |

## What changed

The token section now renders whenever the asset has releases — titled **"Token Releases"** when nothing is available — and both listing and detail **auto-reveal** sold-out entries when there's nothing else to show.

The reveal is *derived*, not assigned into the toggle state, so it can't fight a user's click or flip while data is still loading. The toggle button is suppressed when sold-out entries are all there is, since "Hide" would empty the page.

Sold-out releases lead with the **realised lifetime return in the primary colour**:

```
Token Releases
ALB-WR1-R2  Investor Preview      Returns   SOLD OUT   Lifetime: 26%
ALB-WR1-R1  Community Preview 1   Returns   SOLD OUT   Lifetime: 18%
```

`Current` and `Fully Diluted` are dropped on the card, and `Current` shows **N/A** on the detail page. They are forward returns on a purchase that cannot be made — R1 has already paid 77¢ of its 160¢ lifetime, so pricing it at $1 today is deeply negative and was rendering as **`<0%` beside "Sold Out"**, which reads as a broken figure rather than an inapplicable one. `N/A` matches the returns estimator's existing treatment.

Detail page now reads: `Current N/A · Availability Sold Out · Lifetime 26%`.

## Two bugs found while doing it

1. **Unguarded Buy button** in the mobile card branch — never checked `soldOut`. It was unreachable only because the section was hidden; ungating exposed it. Now guarded like its desktop counterpart.
2. **A vacuous test** in `productionHelpers.spec.ts`: it asserted on `36000 - 35999.999999999999998`. That literal isn't representable as a double and rounds to exactly `36000`, so the assertion evaluated `isEffectivelySoldOut(0)` — duplicating the fully-minted case below it instead of testing the dust value at all. Now expressed as a token count with a non-zero guard. This also clears the `no-loss-of-precision` error introduced in #181.

## Verification

Rendered, not just compiled — trusting the merge is what caused the miss last time. Listing and detail at **1400px and 390px**:

- both releases show `SOLD OUT` with `Lifetime 26%` / `18%`
- no empty state, no Buy button, no `<0%`, no `NaN`, no horizontal scroll
- **221/221 tests**, build clean
- lint **3 errors → 2**; `svelte-check` unchanged at 2 pre-existing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JK7GMn9FL3VZnBUgAAErmD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sold-out asset and token releases now appear automatically when no purchasable options remain.
  * Sold-out releases display their status and lifetime returns, while buy buttons are hidden.
  * Sold-out token releases show “N/A” for current returns.
  * Manual sold-out filters are hidden when sold-out items are automatically displayed.

* **Bug Fixes**
  * Corrected sold-out detection for very small on-chain token supplies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->